### PR TITLE
wp-now: avoid stopping wp-now for lower node versions

### DIFF
--- a/packages/wp-now/src/main.ts
+++ b/packages/wp-now/src/main.ts
@@ -2,13 +2,12 @@ import { runCli } from './run-cli';
 
 const requiredMajorVersion = 18;
 
-const currentNodeVersion = parseInt(process.versions.node.split('.')[0]);
+const currentNodeVersion = parseInt(process.versions?.node?.split('.')?.[0]);
 
 if (currentNodeVersion < requiredMajorVersion) {
-	console.error(
+	console.warn(
 		`You are running Node.js version ${currentNodeVersion}, but this application requires at least Node.js ${requiredMajorVersion}. Please upgrade your Node.js version.`
 	);
-	process.exit(1);
 }
 
 runCli();

--- a/packages/wp-now/src/main.ts
+++ b/packages/wp-now/src/main.ts
@@ -6,7 +6,7 @@ const currentNodeVersion = parseInt(process.versions?.node?.split('.')?.[0]);
 
 if (currentNodeVersion < requiredMajorVersion) {
 	console.warn(
-		`You are running Node.js version ${currentNodeVersion}, but this application requires at least Node.js ${requiredMajorVersion}. Please upgrade your Node.js version.`
+		`You are running Node.js version ${currentNodeVersion}, but this application recommends at least Node.js ${requiredMajorVersion} and isn't guaranteed to work on lower versions. Please upgrade your Node.js version.`
 	);
 }
 


### PR DESCRIPTION
- Closes https://github.com/WordPress/playground-tools/issues/3

### What?

Show a warning message and avoid stopping `wp-now`.

### Why?

- Asked here https://github.com/WordPress/playground-tools/issues/3
- I tested it with node 16, and wp-now works.

### Testing instructions

- Run `nvm use`
- `npm install`
- `npx nx build wp-now`
- `node dist/packages/wp-now/main.js start`
- Observe it works with node 18 without any warning
- Change your current node version: `nvm install 16.0.0`
- `nvm use 16.0.0`
- Run: `node dist/packages/wp-now/main.js start`
- Observe a warning: `You are running Node.js version 16, but this application requires at least Node.js 18. Please upgrade your Node.js version.`
- Observe that wp-now has successfully started.