### PR TITLE
wp now: add codespaces support

### DIFF
--- a/packages/wp-now/src/config.ts
+++ b/packages/wp-now/src/config.ts
@@ -65,7 +65,7 @@ export interface WPEnvOptions {
 async function getAbsoluteURL() {
 	const port = await portFinder.getOpenPort();
 	if (process.env.CODESPACE_NAME) {
-		return `https://${process.env.CODESPACE_NAME}-${port}.github.dev`;
+		return `https://${process.env.CODESPACE_NAME}-${port}.preview.app.github.dev`;
 	}
 	return `http://localhost:${port}`;
 }

--- a/packages/wp-now/src/config.ts
+++ b/packages/wp-now/src/config.ts
@@ -64,6 +64,9 @@ export interface WPEnvOptions {
 
 async function getAbsoluteURL() {
 	const port = await portFinder.getOpenPort();
+	if (process.env.CODESPACE_NAME) {
+		return `https://${process.env.CODESPACE_NAME}-${port}.github.dev`;
+	}
 	return `http://localhost:${port}`;
 }
 

--- a/packages/wp-now/src/config.ts
+++ b/packages/wp-now/src/config.ts
@@ -3,6 +3,7 @@ import {
 	SupportedPHPVersionsList,
 } from '@php-wasm/universal';
 import crypto from 'crypto';
+import { getCodeSpaceURL, isGitHubCodespace } from './github-codespaces';
 import { inferMode } from './wp-now';
 import { portFinder } from './port-finder';
 import { isValidWordPressVersion } from './wp-playground-wordpress';
@@ -64,8 +65,8 @@ export interface WPEnvOptions {
 
 async function getAbsoluteURL() {
 	const port = await portFinder.getOpenPort();
-	if (process.env.CODESPACE_NAME) {
-		return `https://${process.env.CODESPACE_NAME}-${port}.preview.app.github.dev`;
+	if (isGitHubCodespace) {
+		return getCodeSpaceURL(port);
 	}
 	return `http://localhost:${port}`;
 }

--- a/packages/wp-now/src/config.ts
+++ b/packages/wp-now/src/config.ts
@@ -87,7 +87,10 @@ function getWpContentHomePath(projectPath: string, mode: string) {
 export default async function getWpNowConfig(
 	args: CliOptions
 ): Promise<WPNowOptions> {
-	const port = args.port || (await portFinder.getOpenPort());
+	if (args.port) {
+		portFinder.setPort(args.port);
+	}
+	const port = await portFinder.getOpenPort();
 	const optionsFromCli: WPNowOptions = {
 		phpVersion: args.php as SupportedPHPVersion,
 		projectPath: args.path as string,

--- a/packages/wp-now/src/github-codespaces.ts
+++ b/packages/wp-now/src/github-codespaces.ts
@@ -1,0 +1,15 @@
+/*
+ * True if the current environment is a GitHub Codespace
+ */
+export const isGitHubCodespace = Boolean(
+	process.env.CODESPACE_NAME &&
+		process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN
+);
+
+/*
+ * Returns the URL in the current GitHub Codespace
+ * e.g: https://sejas-fluffy-space-eureka-wrj7r95qhvq4x-8881.preview.app.github.dev
+ */
+export function getCodeSpaceURL(port: number): string {
+	return `https://${process.env.CODESPACE_NAME}-${port}.${process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}`;
+}

--- a/packages/wp-now/src/run-cli.ts
+++ b/packages/wp-now/src/run-cli.ts
@@ -141,5 +141,7 @@ function openInDefaultBrowser(url: string) {
 			output?.log(`Platform '${process.platform}' not supported`);
 			return;
 	}
-	spawn(cmd, args);
+	spawn(cmd, args).on('error', function (err) {
+		console.error(err.message);
+	});
 }

--- a/packages/wp-now/src/run-cli.ts
+++ b/packages/wp-now/src/run-cli.ts
@@ -7,6 +7,7 @@ import getWpNowConfig, { CliOptions } from './config';
 import { spawn, SpawnOptionsWithoutStdio } from 'child_process';
 import { executePHP } from './execute-php';
 import { output } from './output';
+import { isGitHubCodespace } from './github-codespaces';
 
 function startSpinner(message: string) {
 	process.stdout.write(`${message}...\n`);
@@ -123,6 +124,9 @@ export async function runCli() {
 }
 
 function openInDefaultBrowser(url: string) {
+	if (isGitHubCodespace) {
+		return;
+	}
 	let cmd: string, args: string[] | SpawnOptionsWithoutStdio;
 	switch (process.platform) {
 		case 'darwin':

--- a/packages/wp-now/src/start-server.ts
+++ b/packages/wp-now/src/start-server.ts
@@ -101,8 +101,7 @@ export async function startServer(
 			output?.trace(e);
 		}
 	});
-
-	const url = `http://localhost:${port}/`;
+	const url = options.absoluteUrl;
 	app.listen(port, () => {
 		output?.log(`Server running at ${url}`);
 	});

--- a/packages/wp-now/src/tests/github-codespaces.spec.ts
+++ b/packages/wp-now/src/tests/github-codespaces.spec.ts
@@ -1,0 +1,37 @@
+import getWpNowConfig from '../config';
+import * as codespaces from '../github-codespaces';
+
+describe('Test GitHub Codespaces', () => {
+	let processEnv;
+	beforeAll(() => {
+		processEnv = process.env;
+		process.env = {};
+	});
+
+	afterAll(() => {
+		process.env = processEnv;
+	});
+
+	test('getAbsoluteURL returns the localhost URL', async () => {
+		vi.spyOn(codespaces, 'isGitHubCodespace', 'get').mockReturnValue(false);
+		const port = 7777;
+		const options = await getWpNowConfig({ port });
+
+		expect(options.absoluteUrl).toBe('http://localhost:7777');
+		vi.resetAllMocks();
+	});
+
+	test('getAbsoluteURL returns the codespace URL', async () => {
+		vi.spyOn(codespaces, 'isGitHubCodespace', 'get').mockReturnValue(true);
+		process.env.CODESPACE_NAME = 'my-codespace-name';
+		process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN =
+			'preview.app.github.dev';
+		const port = 7777;
+		const options = await getWpNowConfig({ port });
+
+		expect(options.absoluteUrl).toBe(
+			'https://my-codespace-name-7777.preview.app.github.dev'
+		);
+		vi.resetAllMocks();
+	});
+});

--- a/packages/wp-now/src/tests/github-codespaces.spec.ts
+++ b/packages/wp-now/src/tests/github-codespaces.spec.ts
@@ -14,8 +14,7 @@ describe('Test GitHub Codespaces', () => {
 
 	test('getAbsoluteURL returns the localhost URL', async () => {
 		vi.spyOn(codespaces, 'isGitHubCodespace', 'get').mockReturnValue(false);
-		const port = 7777;
-		const options = await getWpNowConfig({ port });
+		const options = await getWpNowConfig({ port: 7777 });
 
 		expect(options.absoluteUrl).toBe('http://localhost:7777');
 		vi.resetAllMocks();
@@ -26,8 +25,7 @@ describe('Test GitHub Codespaces', () => {
 		process.env.CODESPACE_NAME = 'my-codespace-name';
 		process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN =
 			'preview.app.github.dev';
-		const port = 7777;
-		const options = await getWpNowConfig({ port });
+		const options = await getWpNowConfig({ port: 7777 });
 
 		expect(options.absoluteUrl).toBe(
 			'https://my-codespace-name-7777.preview.app.github.dev'


### PR DESCRIPTION
## What

Allow running `wp-now` in any GitHub codespace, even in the default one.
- It does not fix it but it's related to #8

## How

- Avoid crashing if we cannot open the browser
- Skip opening the browser for codespaces
- Change the default URL for codespaces which uses port forwarding

## Why

It improves the dev experience and makes it easier to develop WordPress themes and plugins directly from the repo.
It will be great for contributors day.

## Testing steps

- Go to this branch https://github.com/WordPress/playground-tools/tree/add/wp-now-codespaces-support
- Click on `Code` > `Create codespace`
<img width="420" alt="Screenshot 2023-05-31 at 23 41 54" src="https://github.com/WordPress/playground-tools/assets/779993/7829d6ae-fcf4-4148-8a3e-9ae3ee119110">

- Run these commands:

```
git checkout add/wp-now-codespaces-support
nvm install 18.13.0
nvm use 18.13.0
npm install
npx nx build wp-now && node dist/packages/wp-now/main.js start
```

- Click on the printed URL or popup to open the browser. This URL is also available in the ports tab.
- Observe you can access your WordPress instance.
- After this branch is deployed and we release a new `wp-now` version on `npm` we can try it on Gutenberg or core repositories.

## Screencast

https://github.com/WordPress/playground-tools/assets/779993/fcca4dfa-44b0-460a-b7a5-9c2250f929dc

