### PR TITLE
Fix incorrect wp-cli path for test environment

### DIFF
--- a/packages/wp-now/src/get-wp-cli-path.ts
+++ b/packages/wp-now/src/get-wp-cli-path.ts
@@ -9,5 +9,5 @@ export default function getWpCliPath() {
 	if (process.env.NODE_ENV !== 'test') {
 		return path.join(getWpNowPath(), 'wp-cli.phar');
 	}
-	return getWpCliTmpPath();
+	return path.join(getWpCliTmpPath(), 'wp-cli.phar');
 }


### PR DESCRIPTION
In this PR, I propose to fix a bug in a function that gets a path to `wp-cli.phar`.

Currently, for the non-test environment it provides a correct path pointing to `wp-cli.phar` under the `.wp-now` directory, but for the test environment, it returns the temp directory and not the path to the `wp-cli.phar`.

