### PR TITLE
Move wp-now's contributing instructions back to its README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,53 +1,7 @@
 # Contributing
 
-We welcome contributions from the community!
+Each project in WordPress Playground Tools has slightly different contributing instructions. Please refer to the corresponding README:
 
-In order to contribute to `wp-now`, you'll need to first install a few global dependencies:
-
--   Make sure you have `nvm` installed. If you need to install it first,
-    [follow these installation instructions](https://github.com/nvm-sh/nvm#installation).
--   Install `nx` by running `npm install -g nx`.
-
-Once the global dependencies are installed, you can start using the repo:
-
-```bash
-git clone git@github.com:playground-tools
-cd playground-tools
-nvm use
-npm install
-npm run build
-nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme
-```
-
-If you'd like to make the `wp-now` executable globally available when using this installation method, run `npm link`. It's not particularly reliable, however.
-
-Please refer to the main [README.md](../../README.md) file for more detail on how to contribute to this project.
-
-## Testing
-
-To run the unit tests, use the following command:
-
-```bash
-nx test wp-now
-```
-
-## Publishing
-
-The `wp-now` package is part of a larger monorepo, sharing its space with other sibling packages. To publish the `wp-now` package to npm, you must first understand the automated release process facilitated by lerna. This process includes automatically incrementing the version number, creating a new tag, and publishing all modified packages to npm simultaneously. Notably, all published packages share the same version number.
-
-Each package identifies a distinct organization in its `package.json` file. To publish the `wp-now` package, you need access to the `@wp-now` npm organization.
-
-To initiate the publishing process for the all the modified packages, execute the following commands:
-
-```bash
-npm login # this is required only once and it will store the credentials in ~/.npmrc file.
-npm run release
-```
-
-### When publishing goes wrong
-
-Internet connections drop, APIs stop responding, and GitHub rules are nasty. Stuff happens. If the publishing process fails, you may need to bump the version again and force a publish. To do so, execute the following command:
-
-```bash
-npm run release -- --force-publish
-```
+-   [Interactive Code Block](packages/interactive-code-block/README.md)
+-   [VS Code](packages/vscode-extension/README.md)
+-   [wp-now](packages/wp-now/README.md)

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -121,7 +121,7 @@ In order to contribute to `wp-now`, you'll need to first install a few global de
 Once the global dependencies are installed, you can start using the repo:
 
 ```bash
-git clone git@github.com:playground-tools
+git clone git@github.com:WordPress/playground-tools.git
 cd playground-tools
 nvm use
 npm install

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -110,4 +110,52 @@ Some similarities between `wp-env` and `wp-now` to be aware of:
 
 ## Contributing
 
-See [Contributing](CONTRIBUTING.md)
+We welcome contributions from the community!
+
+In order to contribute to `wp-now`, you'll need to first install a few global dependencies:
+
+-   Make sure you have `nvm` installed. If you need to install it first,
+    [follow these installation instructions](https://github.com/nvm-sh/nvm#installation).
+-   Install `nx` by running `npm install -g nx`.
+
+Once the global dependencies are installed, you can start using the repo:
+
+```bash
+git clone git@github.com:playground-tools
+cd playground-tools
+nvm use
+npm install
+npm run build
+nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme
+```
+
+If you'd like to make the `wp-now` executable globally available when using this installation method, run `npm link`. It's not particularly reliable, however.
+
+## Testing
+
+To run the unit tests, use the following command:
+
+```bash
+nx test wp-now
+```
+
+## Publishing
+
+The `wp-now` package is part of a larger monorepo, sharing its space with other sibling packages. To publish the `wp-now` package to npm, you must first understand the automated release process facilitated by lerna. This process includes automatically incrementing the version number, creating a new tag, and publishing all modified packages to npm simultaneously. Notably, all published packages share the same version number.
+
+Each package identifies a distinct organization in its `package.json` file. To publish the `wp-now` package, you need access to the `@wp-now` npm organization.
+
+To initiate the publishing process for the all the modified packages, execute the following commands:
+
+```bash
+npm login # this is required only once and it will store the credentials in ~/.npmrc file.
+npm run release
+```
+
+### When publishing goes wrong
+
+Internet connections drop, APIs stop responding, and GitHub rules are nasty. Stuff happens. If the publishing process fails, you may need to bump the version again and force a publish. To do so, execute the following command:
+
+```bash
+npm run release -- --force-publish
+```


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

Moves wp-now's contributing instructions back to its README.

## Why?

Each project has slightly different contributing instructions, so it makes sense to localize the instructions on each relevant README.