### PR TITLE
VS Code: Update to use latest wp-now internals

### DIFF
--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -13,11 +13,34 @@ Just install this extension, open the WordPress sidebar, and click the "Start Wo
 -   The extension currently expects that the command is run while within a file in the root directory of the plugin. A WordPress playground will still be created and mounted, but the plugin will not be functional if the command is run from an unintended directory.
 -   Some requests may not succeed. This is likely due to the fact that we have a minimally implemented server translation layer.
 
-## Development
+## Contributing
 
-1. Clone the WordPress Playground repository at https://github.com/WordPress/wordpress-playground
-2. Make a change in `packages/vscode-extension`
-3. Go to the Debug tab is your VS Code and run the "Debug Playground for VS Code" configuration. It will build the extension and start a new VS Code window with your changes reflected.
+We welcome contributions from the community!
+
+In order to contribute to the WordPress Playground VS Code Extension, you'll need to have Node.js version 16 or greater installed on your system.
+
+Once you have Node installed, you can start using the repo:
+
+```bash
+git clone git@github.com:WordPress/playground-tools.git
+cd playground-tools
+npm install
+```
+
+After the repo is configured, head back to your VS Code Editor:
+
+1. Enable the Activity Bar, if it isn't enabled already, under View -> Appearance.
+2. Within the Activity Bar, enable 'Run and Debug if it isn't enabled already.
+
+<img width="856" alt="Run and Debug in the Activity Bar" src="https://github.com/WordPress/playground-tools/assets/36432/81c230d9-ff42-461d-880e-53093319f163">
+
+'Run and Debug' is where the magic happens. First, feel free to make whatever changes to `packages/vscode-extension`. Then go to the Debug tab in your VS Code and run the "Debug Playground for VS Code" configuration. It will build the extension and start a new VS Code window with your changes reflected. The WordPress Playground VS Code Extension will appear as a new item in your Activity Bar.
+
+<img width="1290" alt="WordPress Playground VS Code Extension in the Activity Bar" src="https://github.com/WordPress/playground-tools/assets/36432/1f88edb9-ebf7-43c2-87d1-c438c6d6176b">
+
+Any time you make change to the the code, click the reload button at the top of your editor to apply the changes:
+
+<img width="630" alt="Reload button at the top of the editor" src="https://github.com/WordPress/playground-tools/assets/36432/3b9b512c-9b1e-4cb6-b36b-97cff4b2a8df">
 
 [vscode-webview-ui-toolkit](https://github.com/microsoft/vscode-webview-ui-toolkit/blob/main/docs/getting-started.md) is used for UI.
 

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -73,9 +73,17 @@ Any time you make change to the the code, click the reload button at the top of 
 
 ## Publishing
 
+The WordPress Playground VS Code Extension is published independently of the other projects in this repository. However, to ensure they're using the same codebase, a new version of `wp-now` should be released prior to publishing the VS Code Extension.
+
+[@adamziel](https://github.com/adamziel) and [@danielbachhuber](https://github.com/danielbachhuber/) have permissions to publish. The extension is managed in the [VS Code extension marketplace](https://marketplace.visualstudio.com/manage/publishers/wordpressplayground).
+
+Publish a new version by following these steps:
+
 1. Generate a Personal Access Token on https://dev.azure.com/wordpress-playground/_usersSettings/tokens
-1. Login with `vsce login WordPressPlayground` and the token you generated
-1. Build and publish the extension with `vsce publish`.
+2. Login with `vsce login WordPressPlayground` and the token you generated
+3. Build and publish the extension with `nx publish vscode-extension`.
+
+Once you've published the extension, please install it and verify the new version launches a WordPress server as expected.
 
 ## Release Notes
 

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -4,7 +4,28 @@ Run WordPress development server without any dependencies. Yes, you read that ri
 
 This extension bundles [WordPress Playground](https://github.com/WordPress/wordpress-playground), a WebAssembly-based WordPress runtime, and starts a local WordPress development server with a click of a button. That's it! No need to install PHP, MySQL, Apache, or anything else.
 
-Just install this extension, open the WordPress sidebar, and click the "Start WordPress Server" button.
+## Getting Started
+
+Using the WordPress Playground VS Code Extension is just a few steps:
+
+1. Open VS Code.
+2. Search for and install the 'WordPress Playground' extension.
+3. In your VS Code Activity Bar, click on the WordPress icon, and then hit the "Start WordPress Server" button.
+
+Et voilà! WordPress is now running in your default browser with whatever project you currently have open.
+
+### Automatic Modes
+
+The WordPress Playground VS Code Extension automatically operates in a few different modes. The selected mode depends on the project directory in which it is executed:
+
+-   **plugin**, **theme**, or **wp-content**: Loads the project files into a virtual filesytem with WordPress and a SQLite-based database. Everything (including WordPress core files, the database, `wp-config.php`, etc.) is stored in the user's home directory and loaded into the virtual filesystem. Here are the heuristics for each mode:
+    -   **plugin** mode: Presence of a PHP file with 'Plugin Name:' in its contents.
+    -   **theme** mode: Presence of a `style.css` file with 'Theme Name:' in its contents.
+    -   **wp-content** mode: Presence of `plugins` and `themes` subdirectories.
+-   **wordpress**: Runs the directory as a WordPress installation when WordPress files are detected. An existing `wp-config.php` file will be used if it exists; if it doesn't exist, it will be created along with a SQLite database.
+-   **wordpress-develop**: Same as `wordpress` mode, except the `build` directory is served as the web root.
+-   **index**: When an `index.php` file is present, starts a PHP webserver in the working directory and simply passes requests to the `index.php`.
+-   **playground**: If no other conditions are matched, launches a completely virtualized WordPress site.
 
 ## Known Issues
 

--- a/packages/vscode-extension/src/index.ts
+++ b/packages/vscode-extension/src/index.ts
@@ -54,9 +54,9 @@ async function startWordPressServer() {
 		worker.postMessage({
 			command: 'start-server',
 			config: {
-				phpVersion: stateManager.read().phpVersion,
-				wordPressVersion: stateManager.read().wordPressVersion,
-				projectPath: vscode.workspace.workspaceFolders[0].uri.fsPath,
+				php: stateManager.read().phpVersion,
+				wp: stateManager.read().wordPressVersion,
+				path: vscode.workspace.workspaceFolders[0].uri.fsPath,
 			},
 		});
 	} catch (e) {

--- a/packages/vscode-extension/src/state.ts
+++ b/packages/vscode-extension/src/state.ts
@@ -16,7 +16,7 @@ export class InMemoryStateManager extends EventTarget {
 	private state: InMemoryState = {
 		state: 'idle',
 		phpVersion: '7.4',
-		wordPressVersion: '6.2',
+		wordPressVersion: 'latest',
 	};
 
 	read() {

--- a/packages/vscode-extension/src/webview.tsx
+++ b/packages/vscode-extension/src/webview.tsx
@@ -10,7 +10,7 @@ import {
 } from '@vscode/webview-ui-toolkit/react';
 
 // @TODO Move to @wp-playground/wordpress package
-const SupportedWordPressVersions = ['6.2', '6.1', '6.0', '5.9'] as const;
+const SupportedWordPressVersions = {'latest': 'Latest (auto-updated)', '6.2':'6.2', '6.1':'6.1', '6.0':'6.0', '5.9':'5.9'} as Record<string, string>;
 
 // @ts-ignore
 const vscode = acquireVsCodeApi();
@@ -110,12 +110,7 @@ const ServerState = ({ appState }: ServerStateProps) => {
 				{!['core', 'core-develop'].includes(appState.mode) ? (
 					<Dropdown
 						label="WordPress Version:"
-						options={Object.fromEntries(
-							SupportedWordPressVersions.map((version) => [
-								version,
-								version,
-							])
-						)}
+						options={SupportedWordPressVersions}
 						selected={appState.wordPressVersion!}
 						onChange={(value) => {
 							vscode.postMessage({

--- a/packages/vscode-extension/src/webview.tsx
+++ b/packages/vscode-extension/src/webview.tsx
@@ -10,7 +10,13 @@ import {
 } from '@vscode/webview-ui-toolkit/react';
 
 // @TODO Move to @wp-playground/wordpress package
-const SupportedWordPressVersions = {'latest': 'Latest (auto-updated)', '6.2':'6.2', '6.1':'6.1', '6.0':'6.0', '5.9':'5.9'} as Record<string, string>;
+const SupportedWordPressVersions = {
+	latest: 'Latest (auto-updated)',
+	'6.2': '6.2',
+	'6.1': '6.1',
+	'6.0': '6.0',
+	'5.9': '5.9',
+} as Record<string, string>;
 
 // @ts-ignore
 const vscode = acquireVsCodeApi();

--- a/packages/vscode-extension/src/worker.ts
+++ b/packages/vscode-extension/src/worker.ts
@@ -1,8 +1,8 @@
-import { startServer } from '@wp-now/wp-now';
+import { startServer, getWpNowConfig } from '@wp-now/wp-now';
 import { parentPort } from 'worker_threads';
 
 async function start(config: any) {
-	const server = await startServer(config);
+	const server = await startServer(await getWpNowConfig(config));
 	parentPort!.postMessage({
 		...server.options,
 		command: 'server-started',

--- a/packages/wp-now/src/index.ts
+++ b/packages/wp-now/src/index.ts
@@ -1,2 +1,5 @@
+import getWpNowConfig from './config';
+export { getWpNowConfig };
+
 export { startServer } from './start-server';
 export type { WPNowServer } from './start-server';


### PR DESCRIPTION
Fixes https://github.com/WordPress/playground-tools/issues/4

## What?

Updates the VS Code Extension to work with the latest implementation of `wp-now`.

## Why?

It's broken otherwise.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

1. Follow the new CONTRIBUTING instructions to run the VS Code Extension locally.
2. Verify 'Start server' launches a new WordPress Playground.
3. Verify it's possible to switch PHP and WordPress versions.

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->
