### PR TITLE
Fix the dirty package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41605,6 +41605,7 @@
 			}
 		},
 		"packages/interactive-code-block": {
+			"name": "@wp-playground/interactive-code-block",
 			"version": "0.0.1"
 		},
 		"packages/nx-extensions": {


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

When I run `npm install`, `package-lock.json` is dirty with this change.