### PR TITLE
wp-now: Mount the parent theme when running in a child theme

### DIFF
--- a/packages/wp-now/src/tests/mode-examples/child-theme-missing-parent/child/style.css
+++ b/packages/wp-now/src/tests/mode-examples/child-theme-missing-parent/child/style.css
@@ -1,0 +1,10 @@
+/*
+Theme Name: Child Theme
+Description: Child Theme
+Author URI: http://example.com
+Template: parent
+Version: 1.0.0
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: parent-child
+*/

--- a/packages/wp-now/src/tests/mode-examples/child-theme/child/style.css
+++ b/packages/wp-now/src/tests/mode-examples/child-theme/child/style.css
@@ -1,0 +1,10 @@
+/*
+Theme Name: Child Theme
+Description: Child Theme
+Author URI: http://example.com
+Template: parent
+Version: 1.0.0
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: parent-child
+*/

--- a/packages/wp-now/src/tests/mode-examples/child-theme/parent/style.css
+++ b/packages/wp-now/src/tests/mode-examples/child-theme/parent/style.css
@@ -1,0 +1,9 @@
+/*
+Theme Name: Parent Theme
+Description: Parent Theme
+Author URI: http://example.com
+Version: 1.0.0
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: parent
+*/

--- a/packages/wp-now/src/tests/wp-now.spec.ts
+++ b/packages/wp-now/src/tests/wp-now.spec.ts
@@ -536,6 +536,29 @@ describe('Test starting different modes', () => {
 	});
 
 	/**
+	 * Test that startWPNow in "theme" mode auto activates the theme.
+	 */
+	test('startWPNow auto handles child theme with missing parent.', async () => {
+		const projectPath = path.join(
+			tmpExampleDirectory,
+			'child-theme-missing-parent/child'
+		);
+		const options = await getWpNowConfig({ path: projectPath });
+		const { php } = await startWPNow(options);
+
+		const childThemePhp = `<?php
+		require_once('${php.documentRoot}/wp-load.php');
+		echo wp_get_theme()->get('Name');
+		`;
+
+		const childThemeName = await php.run({
+			code: childThemePhp,
+		});
+
+		expect(childThemeName.text).toContain('Child Theme');
+	});
+
+	/**
 	 * Test that startWPNow in "theme" mode does not auto activate the theme the second time.
 	 */
 	test('startWPNow auto installs the theme', async () => {

--- a/packages/wp-now/src/tests/wp-now.spec.ts
+++ b/packages/wp-now/src/tests/wp-now.spec.ts
@@ -1,4 +1,4 @@
-import startWPNow, { inferMode } from '../wp-now';
+import startWPNow, { getThemeTemplate, inferMode } from '../wp-now';
 import getWpNowConfig, { CliOptions, WPNowMode } from '../config';
 import fs from 'fs-extra';
 import path from 'path';
@@ -99,6 +99,18 @@ test('isPluginDirectory returns false for non-plugin directory', () => {
 test('isThemeDirectory detects a WordPress theme and infer THEME mode', () => {
 	const projectPath = exampleDir + '/theme';
 	expect(isThemeDirectory(projectPath)).toBe(true);
+	expect(inferMode(projectPath)).toBe(WPNowMode.THEME);
+});
+
+test('getThemeTemplate detects if a WordPress theme has a parent template.', () => {
+	const projectPath = exampleDir + '/child-theme/child';
+	expect(getThemeTemplate(projectPath)).toBe('parent');
+	expect(inferMode(projectPath)).toBe(WPNowMode.THEME);
+});
+
+test('getThemeTemplate returns falsy value for themes without parent', () => {
+	const projectPath = exampleDir + '/theme';
+	expect(getThemeTemplate(projectPath)).toBe(undefined);
 	expect(inferMode(projectPath)).toBe(WPNowMode.THEME);
 });
 
@@ -487,6 +499,40 @@ describe('Test starting different modes', () => {
 		});
 
 		expect(themeName.text).toContain('Yolo Theme');
+	});
+
+	/**
+	 * Test that startWPNow in "theme" mode auto activates the theme.
+	 */
+	test('startWPNow auto installs mounts child and parent theme.', async () => {
+		const projectPath = path.join(tmpExampleDirectory, 'child-theme/child');
+		const options = await getWpNowConfig({ path: projectPath });
+		const { php } = await startWPNow(options);
+
+		const childThemePhp = `<?php
+		require_once('${php.documentRoot}/wp-load.php');
+		echo wp_get_theme()->get('Name');
+		`;
+
+		const parentThemePhp = `<?php
+		    require_once('${php.documentRoot}/wp-load.php');
+			$theme = wp_get_theme( 'parent' );
+			if ( $theme->exists() ) {
+				echo $theme->get('Name');
+			} else {
+				echo 'Not found';
+			}
+		`;
+
+		const childThemeName = await php.run({
+			code: childThemePhp,
+		});
+		const parentThemeName = await php.run({
+			code: parentThemePhp,
+		});
+
+		expect(childThemeName.text).toContain('Child Theme');
+		expect(parentThemeName.text).toContain('Parent Theme');
 	});
 
 	/**

--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -241,10 +241,17 @@ async function runPluginOrThemeMode(
 		const templateName = getThemeTemplate(projectPath);
 		if (templateName) {
 			// We assume that the theme template is in the parent directory
-			php.mount(
-				path.join(projectPath, '..', templateName),
-				`${documentRoot}/wp-content/${directoryName}/${templateName}`
-			);
+			const templatePath = path.join(projectPath, '..', templateName);
+			if (fs.existsSync(templatePath)) {
+				php.mount(
+					templatePath,
+					`${documentRoot}/wp-content/${directoryName}/${templateName}`
+				);
+			} else {
+				output?.error(
+					`Parent for child theme not found: ${templateName}`
+				);
+			}
 		}
 	}
 	mountSqlitePlugin(php, documentRoot);

--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -329,7 +329,7 @@ async function activatePluginOrTheme(
 	}
 }
 
-function getThemeTemplate(projectPath: string) {
+export function getThemeTemplate(projectPath: string) {
 	const themeTemplateRegex = /^(?:[ \t]*<\?php)?[ \t/*#@]*Template:(.*)$/im;
 	const styleCSS = readFileHead(path.join(projectPath, 'style.css'));
 	if (themeTemplateRegex.test(styleCSS)) {

--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -22,7 +22,7 @@ import {
 	isWordPressDirectory,
 	isWordPressDevelopDirectory,
 	getPluginFile,
-    readFileHead,
+	readFileHead,
 } from './wp-playground-wordpress';
 import { output } from './output';
 import getWpNowPath from './get-wp-now-path';


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->
This pr introduces a fix when the user works in a child theme. In this case, the parent theme is not mounted and this creates a "Missing parent theme" error:
![child_theme_error](https://github.com/WordPress/playground-tools/assets/497103/a4726567-726e-4c7d-87c8-9e6ec10c864f)


## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This pr is the first attempt to fix that error.
There is plenty of discussion about this problem [here](https://github.com/WordPress/playground-tools/issues/33)

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
As a first step to solve this issue, we try to find the parent theme and mount it in the appropriate folder.
We assume that the parent theme is available in the parent directory, and there is some upcoming work to handle more complex scenarios

## Testing Instructions

1. Create a folder with a theme (eg: test), and a child theme (eg: test-child)
2. Run `wp-now start --path=<your-child-theme-path>`
3. Ensure there is no error in the loaded page
4. Move to `/wp-admin/themes.php` and ensure that you:
     - Can activate and deactivate your child theme
     - The parent theme is visible and can be activated and deactivated as well
