### PR TITLE
wp-now: add wp-admin redirection with trailing slash

### DIFF
--- a/packages/wp-now/src/add-trailing-slash.ts
+++ b/packages/wp-now/src/add-trailing-slash.ts
@@ -5,8 +5,11 @@
  */
 export function addTrailingSlash(path) {
 	return (req, res, next) => {
-		if (req.url === path) {
-			res.redirect(301, `${path}/`);
+		const urlParts = req.url.split('?');
+		const url = urlParts[0];
+		const queryString = req.url.substr(url.length);
+		if (url === path) {
+			res.redirect(301, `${path}/${queryString}`);
 		} else {
 			next();
 		}

--- a/packages/wp-now/src/add-trailing-slash.ts
+++ b/packages/wp-now/src/add-trailing-slash.ts
@@ -1,0 +1,14 @@
+/**
+ * Adds redirection adding a trailing slash, when a request matches a given path.
+ * @param path - The path to add a trailing slash to. E.g. '/wp-admin'
+ * @returns  - Returns a middleware function that may redirect adding a trailing slash to the given path. E.g. '/wp-admin/'
+ */
+export function addTrailingSlash(path) {
+	return (req, res, next) => {
+		if (req.url === path) {
+			res.redirect(301, `${path}/`);
+		} else {
+			next();
+		}
+	};
+}

--- a/packages/wp-now/src/start-server.ts
+++ b/packages/wp-now/src/start-server.ts
@@ -7,6 +7,7 @@ import { portFinder } from './port-finder';
 import { NodePHP } from '@php-wasm/node';
 import startWPNow from './wp-now';
 import { output } from './output';
+import { addTrailingSlash } from './add-trailing-slash';
 
 function requestBodyToMultipartFormData(json, boundary) {
 	let multipartData = '';
@@ -32,16 +33,6 @@ const requestBodyToString = async (req) =>
 			resolve(body);
 		});
 	});
-
-function addTrailingSlash(path) {
-	return (req, res, next) => {
-		if (req.url === path) {
-			res.redirect(301, `${path}/`);
-		} else {
-			next();
-		}
-	};
-}
 
 export interface WPNowServer {
 	url: string;

--- a/packages/wp-now/src/start-server.ts
+++ b/packages/wp-now/src/start-server.ts
@@ -33,6 +33,16 @@ const requestBodyToString = async (req) =>
 		});
 	});
 
+function addTrailingSlash(path) {
+	return (req, res, next) => {
+		if (req.url === path) {
+			res.redirect(301, `${path}/`);
+		} else {
+			next();
+		}
+	};
+}
+
 export interface WPNowServer {
 	url: string;
 	php: NodePHP;
@@ -49,6 +59,7 @@ export async function startServer(
 	}
 	const app = express();
 	app.use(fileUpload());
+	app.use(addTrailingSlash('/wp-admin'));
 	const port = await portFinder.getOpenPort();
 	const { php, options: wpNowOptions } = await startWPNow(options);
 

--- a/packages/wp-now/src/tests/add-trailing-slash.spec.ts
+++ b/packages/wp-now/src/tests/add-trailing-slash.spec.ts
@@ -1,0 +1,34 @@
+import { addTrailingSlash } from '../add-trailing-slash';
+
+describe('add trailing slash middleware', () => {
+	const middlewareTrailingSlash = addTrailingSlash('/wp-admin');
+	let res, next;
+
+	beforeEach(() => {
+		res = {
+			redirect: vi.fn(),
+		};
+		next = vi.fn();
+	});
+
+	test('adds a trailing slash to the given path', () => {
+		const req = { url: '/wp-admin' };
+		middlewareTrailingSlash(req, res, next);
+		expect(res.redirect).toHaveBeenCalledWith(301, '/wp-admin/');
+		expect(next).not.toHaveBeenCalled();
+	});
+
+	test('adds a trailing slash to the given path with parameters', () => {
+		const req = { url: '/wp-admin?foo=bar' };
+		middlewareTrailingSlash(req, res, next);
+		expect(res.redirect).toHaveBeenCalledWith(301, '/wp-admin/?foo=bar');
+		expect(next).not.toHaveBeenCalled();
+	});
+
+	test('does not add a trailing slash to the given path', () => {
+		const req = { url: '/wp-admin/' };
+		middlewareTrailingSlash(req, res, next);
+		expect(res.redirect).not.toHaveBeenCalled();
+		expect(next).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

It adds a redirection to `/wp-admin` to add the trailing slash `/wp-admin/` so core loads the correct links in the sidebar.

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- Reported here https://github.com/WordPress/wordpress-playground/issues/461

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I created a middleware to add trailing slash given a path.

## Testing Instructions

- Run `npx nx build wp-now`
- `node dist/packages/wp-now/main.js start`
- Go to `http://127.0.0.1:8881/wp-admin` (without the last slash)
- Observe you are redirected to `http://127.0.0.1:8881/wp-admin/` and the sidebar menu has the correct links.