### PR TITLE
Copy CI tooling from WordPress Playground

### DIFF
--- a/.github/actions/prepare-playground/action.yml
+++ b/.github/actions/prepare-playground/action.yml
@@ -1,0 +1,32 @@
+name: Clone the repository, install dependencies, and configures nx variables
+
+runs:
+    using: 'composite'
+    steps:
+        - name: Fetch trunk
+          shell: bash
+          run: git fetch origin trunk --depth=1
+        - uses: actions/setup-node@v3
+        - name: Cache node modules
+          id: cache-nodemodules
+          uses: actions/cache@v2
+          env:
+              cache-name: cache-node-modules
+          with:
+              # caching node_modules
+              path: node_modules
+              key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+              restore-keys: |
+                  ${{ runner.os }}-build-${{ env.cache-name }}-
+                  ${{ runner.os }}-build-
+                  ${{ runner.os }}-
+        - name: Install Dependencies
+          shell: bash
+          if: steps.cache-nodemodules.outputs.cache-hit != 'true'
+          run: npm ci
+        - name: Set NX_BASE
+          shell: bash
+          run: echo "NX_BASE=$(git rev-parse origin/trunk)" >> $GITHUB_ENV
+        - name: Set NX_HEAD
+          shell: bash
+          run: echo "NX_HEAD=$(git rev-parse HEAD)" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,19 +6,25 @@ on:
     pull_request:
 
 jobs:
-    main:
+    # This step:
+    # * Warms up the node_modules cache
+    # * Performs linting and typechecking
+    #
+    # The linting tasks take ~5s to complete and it doesn't
+    # make sense to separate them into separate steps that would
+    # take ~25s just to run git clone and restore node_modules.
+    lint-and-typecheck:
+        name: 'Lint and typecheck'
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
-              with:
-                  fetch-depth: 0
-            - uses: actions/setup-node@v3
-            - uses: nrwl/nx-set-shas@v3
-              with:
-                  main-branch-name: 'trunk'
-            - run: npm ci
-            - run: npx nx format:check || npx prettier --check .
+            - uses: actions/checkout@v3
+            - uses: ./.github/actions/prepare-playground
+            - run: npx nx affected --target=lint
             - run: npx nx affected --target=typecheck
-            - run: npx nx affected --target=lint --parallel=3
-            - run: npx nx affected --target=test --parallel=3 --configuration=ci
-            - run: npx nx affected --target=build --parallel=3
+    test:
+        runs-on: ubuntu-latest
+        needs: [lint-and-typecheck]
+        steps:
+            - uses: actions/checkout@v3
+            - uses: ./.github/actions/prepare-playground
+            - run: npx nx affected --target=test --configuration=ci


### PR DESCRIPTION
## What?

Copies CI tooling improvements from WordPress Playground, specifically:
* https://github.com/WordPress/wordpress-playground/pull/494
* https://github.com/WordPress/wordpress-playground/pull/496

## Why?

* We should keep CI as consistent as possible between the two repositories.
* It's nice to have linting and testing split into separate jobs, so it's easier to see what fails.
* We'll benefit from a slight performance boost.

## Testing Instructions

1. Verify that all tests are run and pass as expected.