### PR TITLE
Add a failing test case for dirty test directories

### DIFF
--- a/packages/wp-now/src/tests/wp-now.spec.ts
+++ b/packages/wp-now/src/tests/wp-now.spec.ts
@@ -515,6 +515,21 @@ describe('Test starting different modes', () => {
 	});
 
 	/**
+	 * Test that startWPNow doesn't leave dirty files.
+	 *
+	 * @see https://github.com/WordPress/playground-tools/issues/32
+	 */
+	test.skip('startWPNow does not leave dirty folders and files', async () => {
+		const projectPath = path.join(tmpExampleDirectory, 'wordpress');
+		const options = await getWpNowConfig({ path: projectPath });
+		await startWPNow(options);
+		expect(fs.existsSync(path.join(projectPath, 'wp-content', 'mu-plugins', '0-allow-wp-org.php'))).toBe(false);
+		expect(fs.existsSync(path.join(projectPath, 'wp-content', 'database'))).toBe(false);
+		expect(fs.existsSync(path.join(projectPath, 'wp-content', 'plugins', 'sqlite-database-integration'))).toBe(false);
+		expect(fs.existsSync(path.join(projectPath, 'wp-content', 'db.php'))).toBe(false);
+	});
+
+	/**
 	 * Test PHP integration test executing runCli.
 	 */
 	describe('validate php comand arguments passed through yargs', () => {

--- a/packages/wp-now/src/tests/wp-now.spec.ts
+++ b/packages/wp-now/src/tests/wp-now.spec.ts
@@ -523,10 +523,32 @@ describe('Test starting different modes', () => {
 		const projectPath = path.join(tmpExampleDirectory, 'wordpress');
 		const options = await getWpNowConfig({ path: projectPath });
 		await startWPNow(options);
-		expect(fs.existsSync(path.join(projectPath, 'wp-content', 'mu-plugins', '0-allow-wp-org.php'))).toBe(false);
-		expect(fs.existsSync(path.join(projectPath, 'wp-content', 'database'))).toBe(false);
-		expect(fs.existsSync(path.join(projectPath, 'wp-content', 'plugins', 'sqlite-database-integration'))).toBe(false);
-		expect(fs.existsSync(path.join(projectPath, 'wp-content', 'db.php'))).toBe(false);
+		expect(
+			fs.existsSync(
+				path.join(
+					projectPath,
+					'wp-content',
+					'mu-plugins',
+					'0-allow-wp-org.php'
+				)
+			)
+		).toBe(false);
+		expect(
+			fs.existsSync(path.join(projectPath, 'wp-content', 'database'))
+		).toBe(false);
+		expect(
+			fs.existsSync(
+				path.join(
+					projectPath,
+					'wp-content',
+					'plugins',
+					'sqlite-database-integration'
+				)
+			)
+		).toBe(false);
+		expect(
+			fs.existsSync(path.join(projectPath, 'wp-content', 'db.php'))
+		).toBe(false);
 	});
 
 	/**


### PR DESCRIPTION
See https://github.com/WordPress/playground-tools/issues/32
See https://github.com/WordPress/wordpress-playground/issues/503#issuecomment-1574399166

## What?

Adds a failing test case for https://github.com/WordPress/playground-tools/issues/32 and marks it as a skipped test.

## Why?

It will make it easier to evaluate whether https://github.com/WordPress/wordpress-playground/issues/503 fixes the issue.

## Testing Instructions

1. Change `test.skip` to `test.only`.
2. Run `nx test wp-now --watch`.
3. Verify the test fails on the second assertion.
4. Comment out the second assertion and hit save.
5. Verify the test fails on the third assertion.
6. Comment out the third assertion and hit save.
7. Verify the test fails on the fourth assertion.