### PR TITLE
Fix fatal startup crash on windows caused by an invalid mount() path

### DIFF
--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -353,7 +353,7 @@ function mountSqliteDatabaseDirectory(
 	fs.ensureDirSync(path.join(wpContentPath, 'database'));
 	php.mount(
 		path.join(wpContentPath, 'database'),
-		path.join(vfsDocumentRoot, 'wp-content', 'database')
+		`${vfsDocumentRoot}/wp-content/database`
 	);
 }
 

--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -321,7 +321,9 @@ async function activatePluginOrTheme(
 function mountMuPlugins(php: NodePHP, vfsDocumentRoot: string) {
 	php.mount(
 		path.join(getWpNowPath(), 'mu-plugins'),
-		path.join(vfsDocumentRoot, 'wp-content', 'mu-plugins')
+		// VFS paths always use forward / slashes so
+		// we can't use path.join() for them
+		`${vfsDocumentRoot}/wp-content/mu-plugins`
 	);
 }
 


### PR DESCRIPTION
## Description

Solves #11

`wp-now` mounts mu-plugins like this:

```ts
    php.mount(
        path.join(getWpNowPath(), 'mu-plugins'),
        path.join(vfsDocumentRoot, 'wp-content', 'mu-plugins')
    );
```

The first path is the local HOST path, the second path is a VFS path.

On Mac and linux, they both use forward slashes.

On Windows, the first path can use backslashes, but the VFS path still needs to use forward slashes.

Problem is: `path.join()` transforms all slashes to backslashes on Windows, which makes the second path invalid like `\\var\\www\\html`.

This commit corrects that.

## Testing Instructions

Confirm wp-now and the VS code extension can both be started on Windows. Confirm they didn't break on Mac or linux.
