### PR TITLE
wp-now: Fix php cli path error in dev mode

### DIFF
--- a/packages/wp-now/src/execute-php.ts
+++ b/packages/wp-now/src/execute-php.ts
@@ -31,9 +31,11 @@ export async function executePHP(
 
 	try {
 		php.useHostFilesystem();
-		const maybePhpFile = path.join(wpNowOptions.projectPath, phpArgs[1]);
-		if (fs.existsSync(maybePhpFile)) {
-			phpArgs[1] = maybePhpFile;
+		if (!path.isAbsolute(phpArgs[1])) {
+			const maybePhpFile = path.join(wpNowOptions.projectPath, phpArgs[1]);
+			if (fs.existsSync(maybePhpFile)) {
+				phpArgs[1] = maybePhpFile;
+			}
 		}
 		await php.cli(phpArgs);
 	} catch (resultOrError) {

--- a/packages/wp-now/src/execute-php.ts
+++ b/packages/wp-now/src/execute-php.ts
@@ -30,7 +30,10 @@ export async function executePHP(
 
 	try {
 		php.useHostFilesystem();
-		phpArgs[1] = path.join(wpNowOptions.projectPath, path.basename(phpArgs[1]));
+		phpArgs[1] = path.join(
+			wpNowOptions.projectPath,
+			path.basename(phpArgs[1])
+		);
 		await php.cli(phpArgs);
 	} catch (resultOrError) {
 		const success =

--- a/packages/wp-now/src/execute-php.ts
+++ b/packages/wp-now/src/execute-php.ts
@@ -32,7 +32,10 @@ export async function executePHP(
 	try {
 		php.useHostFilesystem();
 		if (!path.isAbsolute(phpArgs[1])) {
-			const maybePhpFile = path.join(wpNowOptions.projectPath, phpArgs[1]);
+			const maybePhpFile = path.join(
+				wpNowOptions.projectPath,
+				phpArgs[1]
+			);
 			if (fs.existsSync(maybePhpFile)) {
 				phpArgs[1] = maybePhpFile;
 			}

--- a/packages/wp-now/src/execute-php.ts
+++ b/packages/wp-now/src/execute-php.ts
@@ -2,7 +2,7 @@ import startWPNow from './wp-now';
 import { WPNowOptions } from './config';
 import { disableOutput } from './output';
 import * as path from 'path';
-import fs from "fs-extra";
+import fs from 'fs-extra';
 
 /**
  * Execute a PHP cli given its parameters.
@@ -31,10 +31,7 @@ export async function executePHP(
 
 	try {
 		php.useHostFilesystem();
-		const maybePhpFile = path.join(
-			wpNowOptions.projectPath,
-			phpArgs[1]
-		);
+		const maybePhpFile = path.join(wpNowOptions.projectPath, phpArgs[1]);
 		if (fs.existsSync(maybePhpFile)) {
 			phpArgs[1] = maybePhpFile;
 		}

--- a/packages/wp-now/src/execute-php.ts
+++ b/packages/wp-now/src/execute-php.ts
@@ -1,6 +1,7 @@
 import startWPNow from './wp-now';
 import { WPNowOptions } from './config';
 import { disableOutput } from './output';
+import * as path from 'path';
 
 /**
  * Execute a PHP cli given its parameters.
@@ -21,7 +22,7 @@ export async function executePHP(
 		);
 	}
 	disableOutput();
-	const { phpInstances } = await startWPNow({
+	const { phpInstances, options: wpNowOptions } = await startWPNow({
 		...options,
 		numberOfPhpInstances: 2,
 	});
@@ -29,6 +30,7 @@ export async function executePHP(
 
 	try {
 		php.useHostFilesystem();
+		phpArgs[1] = path.join(wpNowOptions.projectPath, path.basename(phpArgs[1]));
 		await php.cli(phpArgs);
 	} catch (resultOrError) {
 		const success =

--- a/packages/wp-now/src/execute-php.ts
+++ b/packages/wp-now/src/execute-php.ts
@@ -2,6 +2,7 @@ import startWPNow from './wp-now';
 import { WPNowOptions } from './config';
 import { disableOutput } from './output';
 import * as path from 'path';
+import fs from "fs-extra";
 
 /**
  * Execute a PHP cli given its parameters.
@@ -30,10 +31,13 @@ export async function executePHP(
 
 	try {
 		php.useHostFilesystem();
-		phpArgs[1] = path.join(
+		const maybePhpFile = path.join(
 			wpNowOptions.projectPath,
-			path.basename(phpArgs[1])
+			phpArgs[1]
 		);
+		if (fs.existsSync(maybePhpFile)) {
+			phpArgs[1] = maybePhpFile;
+		}
 		await php.cli(phpArgs);
 	} catch (resultOrError) {
 		const success =

--- a/packages/wp-now/src/tests/execute-php.spec.ts
+++ b/packages/wp-now/src/tests/execute-php.spec.ts
@@ -55,10 +55,7 @@ describe('validate php execution', () => {
 		const options = await getWpNowConfig({
 			path: exampleDir,
 		});
-		await executePHP(
-			['php', 'hello-world.php'],
-			options
-		);
+		await executePHP(['php', 'hello-world.php'], options);
 
 		expect(output).toMatch(/Hello World!/);
 	});

--- a/packages/wp-now/src/tests/execute-php.spec.ts
+++ b/packages/wp-now/src/tests/execute-php.spec.ts
@@ -51,6 +51,17 @@ describe('validate php execution', () => {
 		});
 		expect(output.substring(0, 16)).toBe('PHP Version: 8.2');
 	});
+	test('php file execution with non absolute path', async () => {
+		const options = await getWpNowConfig({
+			path: exampleDir,
+		});
+		await executePHP(
+			['php', 'hello-world.php'],
+			options
+		);
+
+		expect(output).toMatch(/Hello World!/);
+	});
 
 	test('php throws an error if the first element is not the string "php"', async () => {
 		const options = await getWpNowConfig({


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->
Fixes https://github.com/WordPress/playground-tools/issues/16

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->

I get an error when I use wp-now in development mode, symlinked using the `npm link`, and try executing the PHP script in the current directory.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

`wp-now php` should work in both cases consistently.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
PR adds a code that replaces the second argument with its absolute version if the absolute version exists in the filesystem.

## Testing Instructions

1. Create a hello world PHP script
2. Run it with an absolute path
```
$ wp-now php /Volumes/Sites/vip-directory/test.php
```
3. Run it using the relative path
```
$ wp-now php test.php
```

Test both cases for wp-now installed using npm and for wp-now symlinked using `npm link`.
