### PR TITLE
wp-now: Add support for custom URL's

### DIFF
--- a/packages/wp-now/src/config.ts
+++ b/packages/wp-now/src/config.ts
@@ -18,6 +18,8 @@ export interface CliOptions {
 	path?: string;
 	wp?: string;
 	port?: number;
+	siteurl?: string;
+	customport?: number;
 }
 
 export const enum WPNowMode {
@@ -41,6 +43,8 @@ export interface WPNowOptions {
 	wpContentPath?: string;
 	wordPressVersion?: string;
 	numberOfPhpInstances?: number;
+	customSiteURL?: string;
+	customPort?: number;
 }
 
 export const DEFAULT_OPTIONS: WPNowOptions = {
@@ -50,6 +54,8 @@ export const DEFAULT_OPTIONS: WPNowOptions = {
 	projectPath: process.cwd(),
 	mode: WPNowMode.AUTO,
 	numberOfPhpInstances: 1,
+	customSiteURL: null,
+	customPort: null,
 };
 
 export interface WPEnvOptions {
@@ -96,6 +102,8 @@ export default async function getWpNowConfig(
 		projectPath: args.path as string,
 		wordPressVersion: args.wp as string,
 		port,
+		customSiteURL: args.siteurl as string,
+		customPort: args.customport as number,
 	};
 
 	const options: WPNowOptions = {} as WPNowOptions;
@@ -120,6 +128,15 @@ export default async function getWpNowConfig(
 	if (!options.absoluteUrl) {
 		options.absoluteUrl = await getAbsoluteURL();
 	}
+
+	if (options.customSiteURL) {
+		const customPort =
+			options.customPort || (await portFinder.getOpenPort());
+		if (customPort && customPort !== 80) {
+			options.customSiteURL += `:${customPort}`;
+		}
+	}
+
 	if (!isValidWordPressVersion(options.wordPressVersion)) {
 		throw new Error(
 			'Unrecognized WordPress version. Please use "latest" or numeric versions such as "6.2", "6.0.1", "6.2-beta1", or "6.2-RC1"'

--- a/packages/wp-now/src/config.ts
+++ b/packages/wp-now/src/config.ts
@@ -18,7 +18,7 @@ export interface CliOptions {
 	path?: string;
 	wp?: string;
 	port?: number;
-	siteurl?: string;
+	url?: string;
 	customport?: number;
 }
 
@@ -102,7 +102,7 @@ export default async function getWpNowConfig(
 		projectPath: args.path as string,
 		wordPressVersion: args.wp as string,
 		port,
-		customSiteURL: args.siteurl as string,
+		customSiteURL: args.url as string,
 		customPort: args.customport as number,
 	};
 

--- a/packages/wp-now/src/run-cli.ts
+++ b/packages/wp-now/src/run-cli.ts
@@ -39,7 +39,7 @@ function commonParameters(yargs) {
 		})
 		.option('customport', {
 			describe:
-				"Custom port number. Needed if you're using a reverse proxy (e.g. ngrok), usually 80.",
+				"Custom port number. Needed if you're using a tunneling service (e.g. ngrok), usually 80.",
 			type: 'number',
 		});
 }

--- a/packages/wp-now/src/run-cli.ts
+++ b/packages/wp-now/src/run-cli.ts
@@ -32,7 +32,7 @@ function commonParameters(yargs) {
 			describe: 'PHP version to use.',
 			type: 'string',
 		})
-		.option('siteurl', {
+		.option('url', {
 			describe:
 				"Custom site URL to access the site ('home' and 'siteurl' option values).",
 			type: 'string',
@@ -86,7 +86,7 @@ export async function runCli() {
 						php: argv.php as SupportedPHPVersion,
 						wp: argv.wp as string,
 						port: argv.port as number,
-						siteurl: argv.siteurl as string,
+						url: argv.url as string,
 						customport: argv.customport as number,
 					});
 					portFinder.setPort(options.port as number);

--- a/packages/wp-now/src/run-cli.ts
+++ b/packages/wp-now/src/run-cli.ts
@@ -31,6 +31,16 @@ function commonParameters(yargs) {
 		.option('php', {
 			describe: 'PHP version to use.',
 			type: 'string',
+		})
+		.option('siteurl', {
+			describe:
+				"Custom site URL to access the site ('home' and 'siteurl' option values).",
+			type: 'string',
+		})
+		.option('customport', {
+			describe:
+				"Custom port number. Needed if you're using a reverse proxy (e.g. ngrok), usually 80.",
+			type: 'number',
 		});
 }
 
@@ -76,6 +86,8 @@ export async function runCli() {
 						php: argv.php as SupportedPHPVersion,
 						wp: argv.wp as string,
 						port: argv.port as number,
+						siteurl: argv.siteurl as string,
+						customport: argv.customport as number,
 					});
 					portFinder.setPort(options.port as number);
 					const { url } = await startServer(options);

--- a/packages/wp-now/src/start-server.ts
+++ b/packages/wp-now/src/start-server.ts
@@ -103,10 +103,14 @@ export async function startServer(
 			output?.trace(e);
 		}
 	});
-	const url = options.absoluteUrl;
+	const internalUrl = options.absoluteUrl;
+	const customSiteUrl = options.customSiteURL;
 	app.listen(port, () => {
-		output?.log(`Server running at ${url}`);
+		output?.log(`Server running at ${internalUrl}`);
+		customSiteUrl && output?.log(`Custom site URL: ${customSiteUrl}`);
 	});
+
+	const url = customSiteUrl || internalUrl;
 
 	return {
 		url,

--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -154,6 +154,7 @@ async function runWpContentMode(
 		wpContentPath,
 		projectPath,
 		absoluteUrl,
+		customSiteURL,
 	}: WPNowOptions
 ) {
 	const wordPressPath = path.join(
@@ -161,7 +162,12 @@ async function runWpContentMode(
 		wordPressVersion
 	);
 	php.mount(wordPressPath, documentRoot);
-	await initWordPress(php, wordPressVersion, documentRoot, absoluteUrl);
+	await initWordPress(
+		php,
+		wordPressVersion,
+		documentRoot,
+		customSiteURL || absoluteUrl
+	);
 	fs.ensureDirSync(wpContentPath);
 
 	php.mount(projectPath, `${documentRoot}/wp-content`);
@@ -173,18 +179,25 @@ async function runWpContentMode(
 
 async function runWordPressDevelopMode(
 	php: NodePHP,
-	{ documentRoot, projectPath, absoluteUrl }: WPNowOptions
+	{ documentRoot, projectPath, absoluteUrl, customSiteURL }: WPNowOptions
 ) {
 	await runWordPressMode(php, {
 		documentRoot,
 		projectPath: projectPath + '/build',
 		absoluteUrl,
+		customSiteURL,
 	});
 }
 
 async function runWordPressMode(
 	php: NodePHP,
-	{ documentRoot, wpContentPath, projectPath, absoluteUrl }: WPNowOptions
+	{
+		documentRoot,
+		wpContentPath,
+		projectPath,
+		absoluteUrl,
+		customSiteURL,
+	}: WPNowOptions
 ) {
 	php.mount(projectPath, documentRoot);
 
@@ -192,7 +205,7 @@ async function runWordPressMode(
 		php,
 		'user-provided',
 		documentRoot,
-		absoluteUrl
+		customSiteURL || absoluteUrl
 	);
 
 	if (
@@ -214,6 +227,7 @@ async function runPluginOrThemeMode(
 		projectPath,
 		wpContentPath,
 		absoluteUrl,
+		customSiteURL,
 		mode,
 	}: WPNowOptions
 ) {
@@ -222,7 +236,12 @@ async function runPluginOrThemeMode(
 		wordPressVersion
 	);
 	php.mount(wordPressPath, documentRoot);
-	await initWordPress(php, wordPressVersion, documentRoot, absoluteUrl);
+	await initWordPress(
+		php,
+		wordPressVersion,
+		documentRoot,
+		customSiteURL || absoluteUrl
+	);
 
 	fs.ensureDirSync(wpContentPath);
 	fs.copySync(
@@ -260,14 +279,25 @@ async function runPluginOrThemeMode(
 
 async function runWpPlaygroundMode(
 	php: NodePHP,
-	{ documentRoot, wordPressVersion, wpContentPath, absoluteUrl }: WPNowOptions
+	{
+		documentRoot,
+		wordPressVersion,
+		wpContentPath,
+		absoluteUrl,
+		customSiteURL,
+	}: WPNowOptions
 ) {
 	const wordPressPath = path.join(
 		getWordpressVersionsPath(),
 		wordPressVersion
 	);
 	php.mount(wordPressPath, documentRoot);
-	await initWordPress(php, wordPressVersion, documentRoot, absoluteUrl);
+	await initWordPress(
+		php,
+		wordPressVersion,
+		documentRoot,
+		customSiteURL || absoluteUrl
+	);
 
 	fs.ensureDirSync(wpContentPath);
 	fs.copySync(


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

Support for custom URL's and tunneling services (e.g. ngrok).

## Why?

Useful for development, requested by users.

## How?

We add two new CLI options:
- `--url` replaces `WP_HOME` and `WP_SITEURL` values for the site to support custom domain names
- `--customport` is needed for proxying tunneling services (e.g. ngrok)

For local custom domains, it's enough to add the site record into the `hosts` file:
```
127.0.0.1 wpnow-test.local
```
And then pass that value as `--url="http://wpnow-test.local"`
The website will be available at `http://wpnow-test.local:[port]`, with `[port]` being the open port used by wp-now in regular fashion.
The final URL will be displayed in shell and loaded automatically in browser instead of the localhost one:
```
Custom site URL: http://wpnow-test.local:8881
```

If you use ngrok or similar tunneling service, you will need to pass both `--url="http://your-ngrok-domain"` and `--customport=80` because proxying to 8881 (or whatever is generated by wp-now) happens automatically.

Also, there's still no HTTPS supported, so make sure you use `http://` for whatever domain you're proxying.

## Testing Instructions

0. Checkout the branch.

### Local custom domain 
1. Add your custom domain into `hosts` file (e.g. `127.0.0.1 wpnow.local`)
2. Run wp-now with the argument `--url="http://wpnow.local"
3. That URL should get opened in the browser, the site should work fine.

### Tunneling service
1. Establish ngrok proxying: `ngrok http localhost:8882 --scheme=http` (no HTTPS supported yet)
2. Run wp-now: `nx preview wp-now start --port=8882 --url="http://your-ngrok-domain.something" --customport=80`
3. The ngrok domain should load automatically in the browser.
4. If the browser keeps redirecting you to https:// and you aren't able to load the site, try good ol' `curl -i http://your-ngrok-domain.something`