### PR TITLE
Code block: Remove reliance on recommendedWorkerType

### DIFF
--- a/packages/interactive-code-block/src/lib/components/php-runner/php-loader.ts
+++ b/packages/interactive-code-block/src/lib/components/php-runner/php-loader.ts
@@ -1,7 +1,6 @@
 import type { LoadingStatus } from '../../types';
 import {
 	consumeAPI,
-	recommendedWorkerBackend,
 	spawnPHPWorkerThread,
 } from '@php-wasm/web';
 
@@ -26,8 +25,7 @@ export class PHPLoader extends EventTarget {
 			'../../php-worker.ts?url&worker'
 		);
 		const worker = await spawnPHPWorkerThread(
-			workerScriptUrl,
-			recommendedWorkerBackend
+			workerScriptUrl
 		);
 		const php = consumeAPI<PHPClient>(worker);
 		php?.onDownloadProgress((e) => {


### PR DESCRIPTION
Adjusts the interactive code block to use the new `spawnPHPWorkerThread()` signature committed in https://github.com/WordPress/wordpress-playground/pull/471

The old signature was `spawnPHPWorkerThread(url, workerType, options)`

The new signature is `spawnPHPWorkerThread(url, options)` as WASM in ESM WebWorkers is now correctly supported in all major browser.

## Testing Instructions

1. Update npm packages
2. `nx build interactive-code-block`
3. Try that block via wp-now `cd dist/packages/interactive-code-block; wp-now start`
4. Create a post, add a PHP code block, confirm it runs
5. Publish the post, confirm it works on the frontend