### PR TITLE
Interactive code block: Update to the latest wp-playground/client version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
 				"@php-wasm/universal": "0.1.56",
 				"@php-wasm/web": "0.1.57",
 				"@wp-playground/blueprints": "0.1.56",
+				"@wp-playground/client": "0.2.0",
 				"classnames": "^2.3.2",
 				"comlink": "^4.4.1",
 				"compressible": "2.0.18",
@@ -14383,6 +14384,15 @@
 			"version": "0.1.56",
 			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-0.1.56.tgz",
 			"integrity": "sha512-Yvll3D8oLbLgFQLQfDxkgucyLLGi99L9wl0z4+MDmFg4hEegZfP1e+VhjcXHIH3if+2XjMsWKLbUvwwHudzJkg=="
+		},
+		"node_modules/@wp-playground/client": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@wp-playground/client/-/client-0.2.0.tgz",
+			"integrity": "sha512-BSXKJJZv4Yh5qs+gQuRJDMiyQc0uJPRNuRj1gdDhFz8p0NSE5fKfP/M9agnUlf3ijrpubCkt7hMpaLuynd2y3Q==",
+			"engines": {
+				"node": ">=16.15.1",
+				"npm": ">=8.11.0"
+			}
 		},
 		"node_modules/@wp-playground/interactive-code-block": {
 			"resolved": "packages/interactive-code-block",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"@php-wasm/universal": "0.1.56",
 		"@php-wasm/web": "0.1.57",
 		"@wp-playground/blueprints": "0.1.56",
+		"@wp-playground/client": "0.2.0",
 		"classnames": "^2.3.2",
 		"comlink": "^4.4.1",
 		"compressible": "2.0.18",

--- a/packages/interactive-code-block/vite.config.ts
+++ b/packages/interactive-code-block/vite.config.ts
@@ -30,11 +30,6 @@ export default defineConfig({
 		viteStaticCopy({
 			targets: [
 				{
-					src: path('../../dist/packages/playground/client/index.js'),
-					dest: 'assets/',
-					rename: () => 'playground-client.js',
-				},
-				{
 					src: new URL('src/lib/block/editor.css', import.meta.url)
 						.pathname,
 					dest: 'assets/',
@@ -78,6 +73,7 @@ export default defineConfig({
 			preserveEntrySignatures: 'strict',
 			plugins: [react()],
 			input: {
+				['playground-client']: '@wp-playground/client',
 				['comlink']: 'comlink/dist/esm/comlink.mjs',
 				['editor']: path('src/lib/block/editor.tsx'),
 				['view']: path('src/lib/block/view.ts'),
@@ -93,6 +89,8 @@ export default defineConfig({
 				entryFileNames: (entryInfo) => {
 					if (entryInfo.name.includes('comlink')) {
 						return 'assets/comlink.js';
+					} else if (entryInfo.name.includes('playground-client')) {
+						return 'assets/playground-client.js';
 					}
 					return 'assets/[name]-[hash].js';
 				},


### PR DESCRIPTION
This blog post is broken because it uses the old playground client library:

https://adamadam.blog/2023/04/12/interactive-intro-to-wordpress-playground-public-api/

This commit updates the playground client to the most recent version released in npm. This should not affect any other package in the monorepo.
