### PR TITLE
Update wp-now package json repository url

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -7,7 +7,7 @@
 	"version": "0.1.55",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/wordpress-playground"
+		"url": "https://github.com/WordPress/playground-tools"
 	},
 	"icon": "public/icon.png",
 	"engines": {

--- a/packages/wp-now/package.json
+++ b/packages/wp-now/package.json
@@ -4,7 +4,7 @@
 	"description": "WordPress Playground CLI",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/wordpress-playground"
+		"url": "https://github.com/WordPress/playground-tools"
 	},
 	"homepage": "https://developer.wordpress.org/playground",
 	"author": "The WordPress contributors",


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

Sets the Repo URL to point to this repository instead of https://github.com/WordPress/wordpress-playground, where it was previously hosted.

## Why?

Currently, the [npm page for the wp-now](https://www.npmjs.com/package/@wp-now/wp-now) points to the previous repository URL, making it harder to reach the codebase from there.

## Testing Instructions

When published, the GitHub repository link in the npm.org page for wp-now should point to this current repo (https://github.com/WordPress/playground-tools)