### PR TITLE
wp-now: Switch back to Node 18 as minimum supported version

### DIFF
--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -14,6 +14,8 @@ To install `wp-now` directly from `npm`:
 npm install -g @wp-now/wp-now
 ```
 
+Node 18 is the minimum supported version. Node 20 is required for Blueprint support.
+
 Alternatively, you can install `wp-now` via `git clone` if you'd like to hack on it too. See [Contributing](#contributing) for more details.
 
 Once installed, you can start a new server like so:

--- a/packages/wp-now/src/main.ts
+++ b/packages/wp-now/src/main.ts
@@ -1,6 +1,6 @@
 import { runCli } from './run-cli';
 
-const requiredMajorVersion = 20;
+const requiredMajorVersion = 18;
 
 const currentNodeVersion = parseInt(process.versions?.node?.split('.')?.[0]);
 


### PR DESCRIPTION
## What?

Switches back to Node 18 as the minimum supported version. Node 20 is required for Blueprint support (it crashes otherwise).

See https://github.com/WordPress/playground-tools/issues/83
Fixes https://github.com/WordPress/playground-tools/issues/87