### PR TITLE
feat: Add reset project environment CLI option

### DIFF
--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -60,6 +60,7 @@ wp-now php my-file.php
 -   `--port=<port>`: the port number on which the server will listen. This is optional and if not provided, it will pick an open port number automatically. The default port number is set to `8881`(example of usage: `--port=3000`);
 -   `--wp=<version>`: the version of WordPress to use. This is optional and if not provided, it will use a default version. The default version is set to the [latest WordPress version](https://wordpress.org/download/releases/)(example usage: `--wp=5.8`)
 -   `--blueprint=<path>`: the path of a JSON file with the Blueprint steps. This is optional, if provided will execute the defined Blueprints. See [Using Blueprints](#using-blueprints) for more details.
+-   `--reset`: create a fresh SQLite database and wp-content directory, for modes that support persistence.
 
 Of these, `wp-now php` currently supports the `--path=<path>` and `--php=<version>` arguments.
 

--- a/packages/wp-now/src/config.ts
+++ b/packages/wp-now/src/config.ts
@@ -19,6 +19,7 @@ export interface CliOptions {
 	wp?: string;
 	port?: number;
 	blueprint?: string;
+	reset?: boolean;
 }
 
 export const enum WPNowMode {
@@ -43,6 +44,7 @@ export interface WPNowOptions {
 	wordPressVersion?: string;
 	numberOfPhpInstances?: number;
 	blueprintObject?: Blueprint;
+	reset?: boolean;
 }
 
 export const DEFAULT_OPTIONS: WPNowOptions = {
@@ -52,6 +54,7 @@ export const DEFAULT_OPTIONS: WPNowOptions = {
 	projectPath: process.cwd(),
 	mode: WPNowMode.AUTO,
 	numberOfPhpInstances: 1,
+	reset: false,
 };
 
 export interface WPEnvOptions {
@@ -109,6 +112,7 @@ export default async function getWpNowConfig(
 		projectPath: args.path as string,
 		wordPressVersion: args.wp as string,
 		port,
+		reset: args.reset as boolean,
 	};
 
 	const options: WPNowOptions = {} as WPNowOptions;

--- a/packages/wp-now/src/run-cli.ts
+++ b/packages/wp-now/src/run-cli.ts
@@ -71,6 +71,11 @@ export async function runCli() {
 					describe: 'Path to a blueprint file to be executed',
 					type: 'string',
 				});
+				yargs.option('reset', {
+					describe:
+						'Create a new project environment, destroying the old project environment.',
+					type: 'boolean',
+				});
 			},
 			async (argv) => {
 				const spinner = startSpinner('Starting the server...');
@@ -81,6 +86,7 @@ export async function runCli() {
 						wp: argv.wp as string,
 						port: argv.port as number,
 						blueprint: argv.blueprint as string,
+						reset: argv.reset as boolean,
 					});
 					portFinder.setPort(options.port as number);
 					const { url } = await startServer(options);

--- a/packages/wp-now/src/tests/wp-now.spec.ts
+++ b/packages/wp-now/src/tests/wp-now.spec.ts
@@ -790,6 +790,37 @@ describe('Test starting different modes', () => {
 			await stopServer();
 		});
 	});
+
+	describe('reset', () => {
+		let removeSyncSpy;
+		beforeAll(() => {
+			removeSyncSpy = vi
+				.spyOn(fs, 'removeSync')
+				.mockImplementation(() => {});
+		});
+
+		afterAll(() => {
+			removeSyncSpy.mockRestore();
+		});
+
+		test('creates a new environment, destroying the old environment', async () => {
+			const mode = 'theme';
+			const projectPath = path.join(tmpExampleDirectory, mode);
+			const rawOptions: CliOptions = {
+				path: projectPath,
+				reset: true,
+			};
+			const options = await getWpNowConfig(rawOptions);
+			await startWPNow(options);
+			const wpContentPathRegExp = new RegExp(
+				`${getWpNowTmpPath()}\\/wp-content\\/${mode}-[\\w\\d]+`
+			);
+
+			expect(removeSyncSpy).toHaveBeenCalledWith(
+				expect.stringMatching(wpContentPathRegExp)
+			);
+		});
+	});
 });
 
 /**

--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -98,6 +98,11 @@ export default async function startWPNow(
 		downloadSqliteIntegrationPlugin(),
 		downloadMuPlugins(),
 	]);
+
+	if (options.reset) {
+		fs.removeSync(options.wpContentPath);
+	}
+
 	const isFirstTimeProject = !fs.existsSync(options.wpContentPath);
 	await applyToInstances(phpInstances, async (_php) => {
 		switch (options.mode) {

--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -101,6 +101,9 @@ export default async function startWPNow(
 
 	if (options.reset) {
 		fs.removeSync(options.wpContentPath);
+		output?.log(
+			'Created a fresh SQLite database and wp-content directory.'
+		);
 	}
 
 	const isFirstTimeProject = !fs.existsSync(options.wpContentPath);


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->
Simplify the ability to create a new project environment, destroying the
old project environment.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes #30. While the `wp-now` persistence feature is useful for saving changes
to content, settings, etc, sometimes a project environment needs to be reset to
a clean state.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add a `--reset` argument for the `wp-now` CLI. When the argument is passed,
`fs.removeSync` is used to remove the project's associated `wpContentPath`
directory.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->
1. Start a `wp-now` server for a project: `wp-now start --path=<path-to-project>`
1. Persist modifications for the database, e.g. changing or creating content.
1. Stop the `wp-now` server.
1. Restart the `wp-now` server for the same project: 
   `wp-now start --path=<path-to-project>`
1. Verify the persisted modifications remain in-place.
1. Stop the `wp-now` server.
1. Restart the `wp-now` server for the same project with the `--reset` flag:
   `wp-now start --path=<path-to-project> --reset`.
1. Verify the persisted modifications are no longer in-place, the database is
   reset to a clean state.

