### PR TITLE
Require node v20 when `--blueprint=<file>` is used

### DIFF
--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -61,7 +61,7 @@ wp-now php my-file.php
 -   `--php=<version>`: the version of PHP to use. This is optional and if not provided, it will use a default version which is `8.0`(example usage: `--php=7.4`);
 -   `--port=<port>`: the port number on which the server will listen. This is optional and if not provided, it will pick an open port number automatically. The default port number is set to `8881`(example of usage: `--port=3000`);
 -   `--wp=<version>`: the version of WordPress to use. This is optional and if not provided, it will use a default version. The default version is set to the [latest WordPress version](https://wordpress.org/download/releases/)(example usage: `--wp=5.8`)
--   `--blueprint=<path>`: the path of a JSON file with the Blueprint steps. This is optional, if provided will execute the defined Blueprints. See [Using Blueprints](#using-blueprints) for more details.
+-   `--blueprint=<path>`: the path of a JSON file with the Blueprint steps (requires Node 20). This is optional, if provided will execute the defined Blueprints. See [Using Blueprints](#using-blueprints) for more details.
 -   `--reset`: create a fresh SQLite database and wp-content directory, for modes that support persistence.
 
 Of these, `wp-now php` currently supports the `--path=<path>` and `--php=<version>` arguments.

--- a/packages/wp-now/public/with-node-version.js
+++ b/packages/wp-now/public/with-node-version.js
@@ -6,11 +6,13 @@ import fs from 'fs';
 // Set the minimum required/supported version of node here.
 
 // Check if `--blueprint=` is passed in proccess.argv
-const hasBlueprint = process.argv.findIndex((arg) => arg.includes('--blueprint='));
+const hasBlueprint = process.argv.some((arg) =>
+	arg.startsWith('--blueprint=')
+);
 
 const minimum = {
 	// `--blueprint=` requires node v20
-	major: -1 !== hasBlueprint ? 20 : 18,
+	major: hasBlueprint ? 20 : 18,
 	minor: 0,
 	patch: 0,
 };

--- a/packages/wp-now/public/with-node-version.js
+++ b/packages/wp-now/public/with-node-version.js
@@ -4,8 +4,13 @@ import path from 'path';
 import fs from 'fs';
 
 // Set the minimum required/supported version of node here.
+
+// Check if `--blueprint=` is passed in proccess.argv
+const hasBlueprint = process.argv.findIndex((arg) => arg.includes('--blueprint='));
+
 const minimum = {
-	major: 18,
+	// `--blueprint=` requires node v20
+	major: -1 !== hasBlueprint ? 20 : 18,
 	minor: 0,
 	patch: 0,
 };


### PR DESCRIPTION
Fixes https://github.com/WordPress/playground-tools/issues/103

## What?

Updates `with-node-version.js` to require node v20 when the `--blueprint=<file>` flag is used.

## Why?

node v20 is required for Blueprints, but node v18 is required for wp-now. Without this logic, wp-now crashes on node v18 when the `--blueprint=<file>` argument is used.

## Testing Instructions

1. Switch to this branch.
2. Run `npx nx build wp-now` to build the compiled version.
3. Switch to node 14 and observe the following behavior:

```
$ node /path/to/dist/packages/wp-now/with-node-version.js start --php=8.1
This script is requires node version v18.0.0 or above; found v14.21.3
$ node /path/to/dist/packages/wp-now/with-node-version.js start --php=8.1 --blueprint=foo
This script is requires node version v20.0.0 or above; found v14.21.3
```

4. Switch to node v18.
5. Verify `wp-now start` works as expected, but `wp-now start --blueprint=foo` fails.
6. Switch to node v20.
7. Verify `wp-now start` works as expected with and without a `--blueprint=` argument.

cc @dmsnell 