### PR TITLE
wp-now: Clarify Node version difference in error message

### DIFF
--- a/packages/wp-now/public/with-node-version.js
+++ b/packages/wp-now/public/with-node-version.js
@@ -42,8 +42,9 @@ function meetsMinimumVersion(minimum, [major, minor, patch]) {
 }
 
 if (!meetsMinimumVersion(minimum, [major, minor, patch])) {
+	const extra = hasBlueprint ? ' when --blueprint=<file> is used' : '';
 	console.error(
-		`This script is requires node version v${minimum.major}.${minimum.minor}.${minimum.patch} or above; found ${process.version}`
+		`This script is requires node version v${minimum.major}.${minimum.minor}.${minimum.patch} or above${extra}; found ${process.version}`
 	);
 	process.exit(1);
 }


### PR DESCRIPTION
From https://github.com/WordPress/playground-tools/pull/105

## What?

Uses more specific language for the `--blueprint=<file>` error state:

```
This script is requires node version v20.0.0 or above when --blueprint=<file> is used; found v18.17.1
```

Default is:

```
This script is requires node version v18.0.0 or above; found v16.20.1
```

## Why?

To provide greater clarity to the user.

## Testing Instructions


1. Switch to this branch.
2. Run `npx nx build wp-now` to build the compiled version.
3. Switch to node 14 and observe the following behavior:

```
$ node /path/to/dist/packages/wp-now/with-node-version.js start --php=8.1
This script is requires node version v18.0.0 or above; found v14.21.3
$ node /path/to/dist/packages/wp-now/with-node-version.js start --php=8.1 --blueprint=foo
This script is requires node version v20.0.0 or above when --blueprint=<file> is used; found v14.21.3
```