### PR TITLE
Update wp-now's README.md to refer to ~/.wp-now instead of ~/wp-now

### DIFF
--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -139,7 +139,7 @@ Run `wp-now start --blueprint=path/to/blueprint-example.json` where `blueprint-e
 }
 ```
 
-This will enable the debug logs and will create a `debug.log` file in the `~/wp-now/wp-content/${project}/debug.log` directory.
+This will enable the debug logs and will create a `debug.log` file in the `~/.wp-now/wp-content/${project}/debug.log` directory.
 
 If you prefer to set a custom path for the debug log file, you can set `WP_DEBUG_LOG` to be a directory. Remember that the `php-wasm` server runs udner a VFS (virtual file system) where the default documentRoot is always `/var/www/html`.
 


### PR DESCRIPTION
Updates wp-now's README.md to fix a reference to the environment's home directory to read `~/.wp-now` 

## What?

There's a typo in the **Defining Debugging Tools** section when making reference to the environment dir under the user's home dir

## Why?

It's a reference to the wrong dir

## How?

This PR is fixing the typo

## Testing Instructions

Check the [rendered version from this branch under **Defining Debugging Tools**](https://github.com/oskosk/playground-tools/blob/patch-1/packages/wp-now/README.md#defining-debugging-constants) and confirm the path reference makes sense.