### PR TITLE
wp-now: Add proxy support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
 				"file-saver": "^2.0.5",
 				"follow-redirects": "1.15.2",
 				"fs-extra": "11.1.1",
+				"hpagent": "1.2.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"react-modal": "^3.16.1",
@@ -22733,6 +22734,14 @@
 			"dev": true,
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
+			}
+		},
+		"node_modules/hpagent": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+			"integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/hpq": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"file-saver": "^2.0.5",
 		"follow-redirects": "1.15.2",
 		"fs-extra": "11.1.1",
+		"hpagent": "1.2.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-modal": "^3.16.1",

--- a/packages/wp-now/src/download.ts
+++ b/packages/wp-now/src/download.ts
@@ -14,38 +14,19 @@ import { output } from './output';
 import { isValidWordPressVersion } from './wp-playground-wordpress';
 
 function httpsGet(url: string, callback: Function) {
-	const isBehindHttpProxy =
-		(process.env.http_proxy && process.env.http_proxy !== '') ||
-		(process.env.HTTP_PROXY && process.env.HTTP_PROXY !== '');
+	const proxy =
+		process.env.https_proxy ||
+		process.env.HTTPS_PROXY ||
+		process.env.http_proxy ||
+		process.env.HTTP_PROXY;
 
-	const isBehindHttpsProxy =
-		(process.env.https_proxy && process.env.https_proxy !== '') ||
-		(process.env.HTTPS_PROXY && process.env.HTTPS_PROXY !== '');
+	let agent: HttpsProxyAgent | HttpProxyAgent | undefined;
 
-	let agent;
-
-	if (isBehindHttpProxy || isBehindHttpsProxy) {
+	if (proxy) {
 		const urlParts = new URL(url);
-
-		let Agent;
-
-		if (urlParts.protocol === 'https:') {
-			Agent = HttpsProxyAgent;
-		} else if (urlParts.protocol === 'http:') {
-			Agent = HttpProxyAgent;
-		}
-
-		let proxy;
-
-		if (isBehindHttpsProxy) {
-			proxy = process.env.https_proxy ?? process.env.HTTPS_PROXY;
-		} else if (isBehindHttpProxy) {
-			proxy = process.env.http_proxy ?? process.env.HTTP_PROXY;
-		}
-
-		if (Agent && proxy) {
-			agent = new Agent({ proxy });
-		}
+		const Agent =
+			urlParts.protocol === 'https:' ? HttpsProxyAgent : HttpProxyAgent;
+		agent = new Agent({ proxy });
 	}
 
 	https.get(url, { agent }, callback);

--- a/packages/wp-now/src/download.ts
+++ b/packages/wp-now/src/download.ts
@@ -1,17 +1,17 @@
-import fs from 'fs-extra';
-import path from 'path';
 import followRedirects from 'follow-redirects';
-import unzipper from 'unzipper';
-import os from 'os';
-import { IncomingMessage } from 'http';
-import { DEFAULT_WORDPRESS_VERSION, SQLITE_URL, WP_CLI_URL } from './constants';
-import { isValidWordPressVersion } from './wp-playground-wordpress';
-import { output } from './output';
-import getWpNowPath from './get-wp-now-path';
-import getWordpressVersionsPath from './get-wordpress-versions-path';
-import getSqlitePath from './get-sqlite-path';
-import getWpCliPath from './get-wp-cli-path';
+import fs from 'fs-extra';
 import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
+import { IncomingMessage } from 'http';
+import os from 'os';
+import path from 'path';
+import unzipper from 'unzipper';
+import { DEFAULT_WORDPRESS_VERSION, SQLITE_URL, WP_CLI_URL } from './constants';
+import getSqlitePath from './get-sqlite-path';
+import getWordpressVersionsPath from './get-wordpress-versions-path';
+import getWpCliPath from './get-wp-cli-path';
+import getWpNowPath from './get-wp-now-path';
+import { output } from './output';
+import { isValidWordPressVersion } from './wp-playground-wordpress';
 
 function httpsGet(url: string, callback: Function) {
 	const isBehindHttpProxy =


### PR DESCRIPTION
## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->

This pull requests adds support for `https_proxy` and `http_proxy` environment variables to `wp-now` when downloading WordPress and SQLite at `start` time.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Company/enterprise internet connections ofter require proxy configurations. While most GUI applications will inherit these configurations automatically from the system preferences, CLI tools still require manual configuration. It is a common practice to use these well-known environment variables for this purpose: `https_proxy`, `HTTPS_PROXY`, `http_proxy`, `HTTP_PROXY`.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This pull request addresses the problem of not being able to use `wp-now` while connected behind an HTTP(S) proxy by adding the required Agent configuration. To simplify the implementation, I am using [hpagent](https://www.npmjs.com/package/hpagent) which is an abstraction of the http.Agent with proxy support.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
1. Check out the branch.
2. Configure a proxy by exporting the proper proxy configurations.
  ```sh
  export http_proxy=<http://your-http-proxy-url:port>
  export https_proxy=<http://your-https-proxy-url:port>
  ```
3. Start wp-now with `nx preview wp-now start`. Ensure it will download something by either requesting a WordPress version not download previously, or removing your entire $HOME/.wp-now folder.
4. `wp-now` should download its dependencies and start as expected.