### PR TITLE
Code format on `wp-now` and `interactive-code-block`

### DIFF
--- a/packages/interactive-code-block/src/lib/components/php-runner/php-loader.ts
+++ b/packages/interactive-code-block/src/lib/components/php-runner/php-loader.ts
@@ -1,8 +1,5 @@
 import type { LoadingStatus } from '../../types';
-import {
-	consumeAPI,
-	spawnPHPWorkerThread,
-} from '@php-wasm/web';
+import { consumeAPI, spawnPHPWorkerThread } from '@php-wasm/web';
 
 import type { PHPClient } from '../../php-worker';
 
@@ -24,9 +21,7 @@ export class PHPLoader extends EventTarget {
 			/** @ts-ignore */
 			'../../php-worker.ts?url&worker'
 		);
-		const worker = await spawnPHPWorkerThread(
-			workerScriptUrl
-		);
+		const worker = await spawnPHPWorkerThread(workerScriptUrl);
 		const php = consumeAPI<PHPClient>(worker);
 		php?.onDownloadProgress((e) => {
 			const { loaded, total } = e.detail;

--- a/packages/wp-now/public/with-node-version.js
+++ b/packages/wp-now/public/with-node-version.js
@@ -6,9 +6,7 @@ import fs from 'fs';
 // Set the minimum required/supported version of node here.
 
 // Check if `--blueprint=` is passed in proccess.argv
-const hasBlueprint = process.argv.some((arg) =>
-	arg.startsWith('--blueprint=')
-);
+const hasBlueprint = process.argv.some((arg) => arg.startsWith('--blueprint='));
 
 const minimum = {
 	// `--blueprint=` requires node v20


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->

The PR cleans unformatted files that are autoformatted after each commit. It just removes break lines.
Not sure why the formatting rules have changed.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

These file changes produce noise after each commit. 

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The formatting command is `npx nx format`

## Testing Instructions
- Run `npx nx format`
- Observe that no file is modified.
- `wp-now` and `interactive-code-block` should work as expected

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->
