### PR TITLE
Add a blueprint.json file to the interactive-code-block plugin

### DIFF
--- a/packages/interactive-code-block/public/blueprint.json
+++ b/packages/interactive-code-block/public/blueprint.json
@@ -1,0 +1,28 @@
+{
+  "landingPage": "/wp-admin/post.php?post=4&action=edit",
+  "steps": [
+    {
+      "step": "login",
+      "username": "admin",
+      "password": "password"
+    },
+    {
+      "step": "installTheme",
+      "themeZipFile": {
+        "resource": "wordpress.org/themes",
+        "slug": "adventurer"
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginZipFile": {
+        "resource": "wordpress.org/plugins",
+        "slug": "interactive-code-block"
+      }
+    },
+    {
+      "step": "runPHP",
+      "code": "<?php require '/wordpress/wp-load.php'; wp_insert_post(['post_title' => 'Interactive code block demo!','post_content' => '<!-- wp:wordpress-playground/interactive-code {\"code\":\"PD9waHAKCmVjaG8gIlRoaXMgY29kZSBzbmlwcGV0IGlzIGludGVyYWN0aXZlISI7Cg==\",\"cachedOutput\":\"VGhpcyBjb2RlIHNuaXBwZXQgaXMgaW50ZXJhY3RpdmUh\"} --><div class=\"wp-block-wordpress-playground-interactive-code\">PD9waHAKCmVjaG8gIlRoaXMgY29kZSBzbmlwcGV0IGlzIGludGVyYWN0aXZlISI7Cg==</div><!-- /wp:wordpress-playground/interactive-code -->', 'post_status' => 'publish', 'post_type' => 'post',]);"
+    }
+  ]
+}


### PR DESCRIPTION
Let's prepare for the upcoming Plugin Preview feature in the WordPress plugin directory.

## Testing instructions

Apply the Blueprint and confirm you're redirected to the post editor with an interactive code block embedded.

<img width="1012" alt="CleanShot 2023-11-19 at 14 39 18@2x" src="https://github.com/WordPress/playground-tools/assets/205419/71393fbd-2a4c-4c00-9dca-b75eb0c0d56f">
