### PR TITLE
[DRAFT] Moving @php-wasm/node's files correctly when sourcemaps & source trees are present

### DIFF
--- a/packages/vscode-extension/project.json
+++ b/packages/vscode-extension/project.json
@@ -46,7 +46,7 @@
 					"cp ./LICENSE dist/packages/vscode-extension",
 					"cp packages/vscode-extension/package.json dist/packages/vscode-extension",
 					"cp packages/vscode-extension/README.md dist/packages/vscode-extension",
-					"cp node_modules/@php-wasm/node/*.wasm dist/packages/vscode-extension"
+					"find node_modules/@php-wasm/node/ -type f -name php_*.wasm | while read FILE; do cp $FILE dist/packages/vscode-extension; done"
 				],
 				"parallel": false
 			}


### PR DESCRIPTION
# DRAFT

## What?

This ensures @php-wasm/nodes' files are copied properly when the wordpress-playground package has been built with sourcemaps.

## Why?

When wordpress-playground builds php-wasm with sourcemaps, the directory structure changes slightly. This change updates the code to account for that.

## How?

It iterates over the directory where the sub-directories containing the files live, and moves them, preserving the sub-paths.

## Testing Instructions

...