### PR TITLE
[DRAFT] Removing rm for php5 from interactive-code-block's project.json

### DIFF
--- a/packages/interactive-code-block/project.json
+++ b/packages/interactive-code-block/project.json
@@ -14,7 +14,6 @@
 				"cwd": "dist/packages",
 				"commands": [
 					"cp ../../packages/interactive-code-block/README.md ./interactive-code-block/",
-					"rm interactive-code-block/assets/php_5*",
 					"rm interactive-code-block/assets/php_7_0*",
 					"rm interactive-code-block/assets/php_7_1*",
 					"rm interactive-code-block/assets/php_7_2*",


### PR DESCRIPTION
# DRAFT

## What?

This PR removes the reference to the unused PHP 5 from `interactive-code-block`'s `project.json`.

## Why?

PHP 5 is being deprecated from @php-wasm.

## How?

By deleting the line.

## Testing Instructions

Check out the branch, pull dependencies

```bash
git checkout sm-cleanup-icb-project-json
npm install
```

Reset NX

```
nx reset
```

Run the build, check to see that the error is gone:

```bash
npm run build
```