### PR TITLE
VSCode extension: Copy wasm files from correct folders

### DIFF
--- a/packages/vscode-extension/project.json
+++ b/packages/vscode-extension/project.json
@@ -46,7 +46,7 @@
 					"cp ./LICENSE dist/packages/vscode-extension",
 					"cp packages/vscode-extension/package.json dist/packages/vscode-extension",
 					"cp packages/vscode-extension/README.md dist/packages/vscode-extension",
-					"cp node_modules/@php-wasm/node/*.wasm dist/packages/vscode-extension"
+					"cp -r node_modules/@php-wasm/node/*_*_* dist/packages/vscode-extension"
 				],
 				"parallel": false
 			}

--- a/packages/vscode-extension/project.json
+++ b/packages/vscode-extension/project.json
@@ -46,7 +46,8 @@
 					"cp ./LICENSE dist/packages/vscode-extension",
 					"cp packages/vscode-extension/package.json dist/packages/vscode-extension",
 					"cp packages/vscode-extension/README.md dist/packages/vscode-extension",
-					"cp -r node_modules/@php-wasm/node/*_*_* dist/packages/vscode-extension"
+					"cp -r node_modules/@php-wasm/node/7_* dist/packages/vscode-extension",
+					"cp -r node_modules/@php-wasm/node/8_* dist/packages/vscode-extension"
 				],
 				"parallel": false
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->

Update the copy wasm files build step for `vscode-extension`.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

`npm run build` was returning an error for VSCode:

```
❯ npm run build                                                      х INT Node 18.18.2 13:16:42

> wp-playground@0.0.0 build
> nx run-many --all --target=build


    ✔  nx run wp-now:build:bundle (246ms)
    ✔  nx run wp-now:build:package-json (567ms)

    ✖  nx run vscode-extension:build:bundle
       cp: node_modules/@php-wasm/node/*.wasm: No such file or directory
       Warning: run-commands command "cp node_modules/@php-wasm/node/*.wasm dist/packages/vscode-extension" exited with non-zero status code
    ✔  nx run wp-now:build  [local cache]
    ✔  nx run nx-extensions:build  [existing outputs match the cache, left as is]
    ✔  nx run playground-demo-block:build:bundle (16s)
    ✔  nx run playground-demo-block:build:zip (234ms)
    ✔  nx run playground-demo-block:build  [local cache]
    ✔  nx run interactive-code-block:build:bundle (20s)

    ✖  nx run interactive-code-block:build:zip
       rm: interactive-code-block/assets/php_5*: No such file or directory
       Warning: run-commands command "rm interactive-code-block/assets/php_5*" exited with non-zero status code

 ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 >  NX   Ran target build for 5 projects and 8 tasks they depend on (20s)
 
    ✔    8/10 succeeded [3 read from cache]
 
    ✖    2/10 targets failed, including the following:
         - nx run vscode-extension:build:bundle
         - nx run interactive-code-block:build:zip
 
   Hint: Try "nx view-logs" to get structured, searchable errors logs in your browser.
```

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The `node/@php-wasm` has changed the files structure. I updated the command that copies the wasm.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->

1. Run `nvm use && npm run build`
2. Observe no errors are thrown for `vscode-extension`.
3. Observe a success message ` ✔  nx run vscode-extension:build (338ms)`