### PR TITLE
WIP: Create GitHub action publish-npm-packages.yml to deploy wp-now

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -1,0 +1,54 @@
+name: Release NPM packages
+
+on:
+    workflow_dispatch:
+        # Require a version bump (patch, minor, major) and an optional dist tag
+        inputs:
+            version_bump:
+                description: 'Version bump (patch, minor, or major)'
+                required: true
+                default: 'patch'
+            dist_tag:
+                description: 'Dist tag (latest, next, etc.)'
+                required: false
+                default: 'latest'
+
+jobs:
+    release:
+        # Only run this workflow from the trunk branch and when it's triggered by an authorized user
+        if: >
+            github.ref == 'refs/heads/trunk' && (
+                github.actor == 'adamziel' ||
+                github.actor == 'danielbachhuber' ||
+                github.actor == 'dmsnell' ||
+                github.actor == 'sejas'
+            )
+
+        # Specify runner + deployment step
+        runs-on: ubuntu-latest
+        environment:
+            name: npm
+        env:
+            NPM_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  ref: ${{ github.event.pull_request.head.ref }}
+                  clean: true
+                  fetch-depth: 0
+                  persist-credentials: false
+            - name: Config git user
+              run: |
+                  git config --global user.name "deployment_bot"
+                  git config --global user.email "deployment_bot@users.noreply.github.com"
+                  git remote set-url origin https://${{ secrets.GH_ACTOR }}:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}
+            - name: Authenticate with Registry
+              run: |
+                  echo "@wp-now:registry=https://registry.npmjs.org/" > ~/.npmrc
+                  echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
+                  echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+            - uses: ./.github/actions/prepare-playground
+            # Version bump, release, tag a new version on GitHub
+            - name: Release new version of NPM packages
+              shell: bash
+              run: npx lerna@6.6.2 publish ${{ inputs.version_bump }} --yes --no-private --loglevel=verbose --dist-tag=${{ inputs.dist_tag }}


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

Let's create a GitHub action to deploy a new npm version for `wp-now`.

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Creating an action will be easier for anyone authorized to create a release.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This GitHub action is similar to https://github.com/WordPress/wordpress-playground/blob/trunk/.github/workflows/publish-npm-packages.yml

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->

TBD