### PR TITLE
Playground Block: Accept a Blueprint URL so setup Playground using remote JSON Blueprints

### DIFF
--- a/packages/playground-demo-block/src/block.json
+++ b/packages/playground-demo-block/src/block.json
@@ -63,6 +63,13 @@
 			"type": "string",
 			"default": "front"
 		},
+		"configurationSource": {
+			"type": "string",
+			"default": "block-attributes"
+		},
+		"blueprintUrl": {
+			"type": "string"
+		},
 		"blueprint": {
 			"type": "string"
 		}

--- a/packages/playground-demo-block/src/edit.tsx
+++ b/packages/playground-demo-block/src/edit.tsx
@@ -37,6 +37,8 @@ export default function Edit({
 		redirectToPost,
 		redirectToPostType,
 		blueprint,
+		blueprintUrl,
+		configurationSource,
 	} = attributes;
 
 	return (
@@ -161,138 +163,185 @@ export default function Edit({
 							</>
 						)}
 					</PanelBody>
-					<PanelBody title="Playground" initialOpen={false}>
-						<ToggleControl
-							label="Log in automatically"
-							help={
-								logInUser
-									? 'User will be logged in.'
-									: "User won't be logged in."
-							}
-							checked={logInUser}
-							onChange={() => {
+					<PanelBody title="Blueprint" initialOpen={false}>
+						<SelectControl
+							label="Blueprint source"
+							value={configurationSource}
+							options={[
+								{
+									label: 'Generate from block attributes',
+									value: 'block-attributes',
+								},
+								{
+									label: 'URL',
+									value: 'blueprint-url',
+								},
+								{
+									label: 'JSON (paste it below)',
+									value: 'blueprint-json',
+								},
+							]}
+							onChange={(newConfigurationSource) => {
 								setAttributes({
-									logInUser: !logInUser,
+									configurationSource: newConfigurationSource,
 								});
 							}}
-						/>
-						<ToggleControl
-							label="Create new post or page"
 							help={
-								createNewPost
-									? 'New post or page will be created.'
-									: 'No new posts or pages will be created.'
+								'Playground is configured using Blueprints. Select the source ' +
+								"of the Blueprint you'd like to use for this Playground instance."
 							}
-							checked={createNewPost}
-							onChange={() => {
-								setAttributes({
-									createNewPost: !createNewPost,
-								});
-							}}
 						/>
-						{createNewPost && (
+						{configurationSource === 'block-attributes' && (
 							<>
-								<ToggleGroupControl
-									label="Create new: post type"
-									value={createNewPostType}
-									onChange={(value: any) => {
-										setAttributes({
-											createNewPostType:
-												value?.toString(),
-										});
-									}}
-									isBlock
-								>
-									<ToggleGroupControlOption
-										value="post"
-										label="Post"
-									/>
-									<ToggleGroupControlOption
-										value="page"
-										label="Page"
-									/>
-								</ToggleGroupControl>
-								<InputControl
-									value={createNewPostTitle}
-									onChange={(value: any) => {
-										setAttributes({
-											createNewPostTitle: value,
-										});
-									}}
-									label="Create new: title"
-									placeholder="Hello World!"
-								/>
-								<TextareaControl
-									value={createNewPostContent}
-									onChange={(value) => {
-										setAttributes({
-											createNewPostContent: value,
-										});
-									}}
-									label="Create new: content"
-									help="Gutenberg editor content of the post"
-								/>
 								<ToggleControl
-									label="Create new: redirect to post"
+									label="Log in automatically"
 									help={
-										redirectToPost
-											? 'User will be redirected.'
-											: "User won't be redirected."
+										logInUser
+											? 'User will be logged in.'
+											: "User won't be logged in."
 									}
-									checked={redirectToPost}
+									checked={logInUser}
 									onChange={() => {
 										setAttributes({
-											redirectToPost: !redirectToPost,
+											logInUser: !logInUser,
 										});
 									}}
 								/>
-								{redirectToPost && (
-									<ToggleGroupControl
-										label="Create new redirect: redirect to"
-										value={redirectToPostType}
+								<ToggleControl
+									label="Create new post or page"
+									help={
+										createNewPost
+											? 'New post or page will be created.'
+											: 'No new posts or pages will be created.'
+									}
+									checked={createNewPost}
+									onChange={() => {
+										setAttributes({
+											createNewPost: !createNewPost,
+										});
+									}}
+								/>
+								{createNewPost && (
+									<>
+										<ToggleGroupControl
+											label="Create new: post type"
+											value={createNewPostType}
+											onChange={(value: any) => {
+												setAttributes({
+													createNewPostType:
+														value?.toString(),
+												});
+											}}
+											isBlock
+										>
+											<ToggleGroupControlOption
+												value="post"
+												label="Post"
+											/>
+											<ToggleGroupControlOption
+												value="page"
+												label="Page"
+											/>
+										</ToggleGroupControl>
+										<InputControl
+											value={createNewPostTitle}
+											onChange={(value: any) => {
+												setAttributes({
+													createNewPostTitle: value,
+												});
+											}}
+											label="Create new: title"
+											placeholder="Hello World!"
+										/>
+										<TextareaControl
+											value={createNewPostContent}
+											onChange={(value) => {
+												setAttributes({
+													createNewPostContent: value,
+												});
+											}}
+											label="Create new: content"
+											help="Gutenberg editor content of the post"
+										/>
+										<ToggleControl
+											label="Create new: redirect to post"
+											help={
+												redirectToPost
+													? 'User will be redirected.'
+													: "User won't be redirected."
+											}
+											checked={redirectToPost}
+											onChange={() => {
+												setAttributes({
+													redirectToPost:
+														!redirectToPost,
+												});
+											}}
+										/>
+										{redirectToPost && (
+											<ToggleGroupControl
+												label="Create new redirect: redirect to"
+												value={redirectToPostType}
+												onChange={(value: any) => {
+													setAttributes({
+														redirectToPostType:
+															value?.toString(),
+													});
+												}}
+												isBlock
+											>
+												<ToggleGroupControlOption
+													value="front"
+													label="Front page"
+												/>
+												<ToggleGroupControlOption
+													value="admin"
+													label="Edit screen"
+												/>
+											</ToggleGroupControl>
+										)}
+									</>
+								)}
+								{(!createNewPost || !redirectToPost) && (
+									<InputControl
+										value={landingPageUrl}
 										onChange={(value: any) => {
 											setAttributes({
-												redirectToPostType:
-													value?.toString(),
+												landingPageUrl: value,
 											});
 										}}
-										isBlock
-									>
-										<ToggleGroupControlOption
-											value="front"
-											label="Front page"
-										/>
-										<ToggleGroupControlOption
-											value="admin"
-											label="Edit screen"
-										/>
-									</ToggleGroupControl>
+										label="Landing page"
+										help="Define where to redirect after Playground is loaded."
+										placeholder="URL to redirect to after load (eg. /wp-admin/)"
+									/>
 								)}
 							</>
 						)}
-						{(!createNewPost || !redirectToPost) && (
+						{configurationSource === 'blueprint-url' && (
 							<InputControl
-								value={landingPageUrl}
+								value={blueprintUrl}
 								onChange={(value: any) => {
 									setAttributes({
-										landingPageUrl: value,
+										blueprintUrl: value,
 									});
 								}}
-								label="Landing page"
-								help="Define where to redirect after Playground is loaded."
-								placeholder="Got to url after load (eg. /wp-admin/)"
+								label="Blueprint URL"
+								help="Load Blueprint from this URL."
+								placeholder="URL to load the Blueprint from"
 							/>
 						)}
-						<TextareaControl
-							value={blueprint}
-							onChange={(value) => {
-								setAttributes({
-									blueprint: value,
-								});
-							}}
-							label="Blueprint"
-							help="JSON file with playground blueprint"
-						/>
+						{configurationSource === 'blueprint-json' && (
+							<TextareaControl
+								value={blueprint}
+								onChange={(value) => {
+									setAttributes({
+										blueprint: value,
+									});
+								}}
+								label="Blueprint"
+								help="JSON file with playground blueprint"
+							/>
+						)}
 					</PanelBody>
 				</Panel>
 			</InspectorControls>

--- a/packages/playground-demo-block/src/index.ts
+++ b/packages/playground-demo-block/src/index.ts
@@ -22,6 +22,11 @@ export type Attributes = {
 	redirectToPost: boolean;
 	redirectToPostType: string;
 	blueprint: string;
+	blueprintUrl: string;
+	configurationSource:
+		| 'block-attributes'
+		| 'blueprint-url'
+		| 'blueprint-json';
 	files?: File[];
 };
 


### PR DESCRIPTION
## What?

Adds a Blueprint URL block attribute to enable loading Blueprints from remote sources. This means you can maintain a single Blueprint as a source of truth for multiple posts and demos, and never worry about going back to update your posts whenever that Blueprint changes.

<img width="1276" alt="CleanShot 2024-01-16 at 13 10 03@2x" src="https://github.com/WordPress/playground-tools/assets/205419/0ae35101-bf7a-4892-94b2-82c97e42f710">

Closes https://github.com/WordPress/playground-tools/issues/140

🚧  work in progress