### PR TITLE
Playground Block – fix help text, render the block only after DOM load

### DIFF
--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -169,7 +169,12 @@ export default function PlaygroundPreview({
 
 			const configuration = {
 				iframe: iframeRef.current,
-				remoteUrl: 'https://playground.wordpress.net/remote.html',
+				// wasm.wordpress.net is alias for playground.wordpress.net at the moment.
+				// @TODO: Use playground.wordpress.net once the service worker
+				//        is updated. The current one tries to serve the remote.html
+				//        file from a /wp-6.4/ path when this block is used on
+				//        playground.wordpress.net, and that returns a 404.html.
+				remoteUrl: 'https://wasm.wordpress.net/remote.html',
 			} as any;
 			if (finalBlueprint) {
 				configuration['blueprint'] = finalBlueprint;

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -169,12 +169,7 @@ export default function PlaygroundPreview({
 
 			const configuration = {
 				iframe: iframeRef.current,
-				// wasm.wordpress.net is alias for playground.wordpress.net at the moment.
-				// @TODO: Use playground.wordpress.net once the service worker
-				//        is updated. The current one tries to serve the remote.html
-				//        file from a /wp-6.4/ path when this block is used on
-				//        playground.wordpress.net, and that returns a 404.html.
-				remoteUrl: 'https://wasm.wordpress.net/remote.html',
+				remoteUrl: 'https://playground.wordpress.net/remote.html',
 			} as any;
 			if (finalBlueprint) {
 				configuration['blueprint'] = finalBlueprint;

--- a/packages/wordpress-playground-block/src/edit.tsx
+++ b/packages/wordpress-playground-block/src/edit.tsx
@@ -214,6 +214,10 @@ export default function Edit({
 									configurationSource: newConfigurationSource,
 								});
 							}}
+							help={
+								'Playground is configured using Blueprints. Select the source ' +
+								"of the Blueprint you'd like to use for this Playground instance."
+							}
 						/>
 						{configurationSource === 'block-attributes' && (
 							<>
@@ -230,13 +234,6 @@ export default function Edit({
 											logInUser: !logInUser,
 										});
 									}}
-								/>
-								<ToggleControl
-									label="Create new post or page"
-									help={
-										'Playground is configured using Blueprints. Select the source ' +
-										"of the Blueprint you'd like to use for this Playground instance."
-									}
 								/>
 								<ToggleControl
 									label="Create new post or page"

--- a/packages/wordpress-playground-block/src/view.tsx
+++ b/packages/wordpress-playground-block/src/view.tsx
@@ -2,16 +2,24 @@ import React from 'react';
 import { createRoot } from '@wordpress/element';
 import PlaygroundPreview from './components/playground-preview';
 
-const playgroundDemo = Array.from(
-	document.getElementsByClassName('wordpress-playground-block')
-);
-
-for (const element of playgroundDemo) {
-	const rootElement = element as HTMLDivElement;
-	const root = createRoot(rootElement);
-	const attributes = JSON.parse(
-		atob(rootElement.dataset['attributes'] || '')
+function renderPlaygroundPreview() {
+	const playgroundDemo = Array.from(
+		document.getElementsByClassName('wordpress-playground-block')
 	);
 
-	root.render(<PlaygroundPreview {...attributes} />);
+	for (const element of playgroundDemo) {
+		const rootElement = element as HTMLDivElement;
+		const root = createRoot(rootElement);
+		const attributes = JSON.parse(
+			atob(rootElement.dataset['attributes'] || '')
+		);
+
+		root.render(<PlaygroundPreview {...attributes} />);
+	}
+}
+
+if (document.readyState === 'loading') {
+	document.addEventListener('DOMContentLoaded', renderPlaygroundPreview);
+} else {
+	renderPlaygroundPreview();
 }

--- a/packages/wordpress-playground-block/wordpress-playground-block.php
+++ b/packages/wordpress-playground-block/wordpress-playground-block.php
@@ -4,7 +4,7 @@
  * Description:       WordPress Playground as a Gutenberg block.
  * Requires at least: 6.1
  * Requires PHP:      7.0
- * Version:           0.1.0
+ * Version:           0.1.1
  * Author:            Dawid Urbański, Adam Zieliński
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/packages/wordpress-playground-block/wordpress-playground-block.php
+++ b/packages/wordpress-playground-block/wordpress-playground-block.php
@@ -4,7 +4,7 @@
  * Description:       WordPress Playground as a Gutenberg block.
  * Requires at least: 6.1
  * Requires PHP:      7.0
- * Version:           0.1.1
+ * Version:           0.1.4
  * Author:            Dawid Urbański, Adam Zieliński
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
* Fixes the misattributed help text in the Block Inspector
* Renders the Playground block only after DOM load
