### PR TITLE
WP-NOW: Export getWpNowPath to use it externally

### DIFF
--- a/packages/wp-now/src/index.ts
+++ b/packages/wp-now/src/index.ts
@@ -1,5 +1,6 @@
 import getWpNowConfig from './config';
 export { getWpNowConfig };
 
+export { default as getWpNowPath } from './get-wp-now-path';
 export { startServer } from './start-server';
 export type { WPNowServer } from './start-server';


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->
It shares the `getWpNowPath` function.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It will be useful to re-use the same path from the package instead of building the same path in different apps.


## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->
* Run `npm run build`
* Observe that in built file `dist/packages/wp-now/index.js` the `getWpNowPath` function exists and is exported.
