### PR TITLE
Add "playground" keyword to Playground Block.

### DIFF
--- a/packages/wordpress-playground-block/src/block.json
+++ b/packages/wordpress-playground-block/src/block.json
@@ -7,6 +7,7 @@
 	"category": "widgets",
 	"icon": "wordpress",
 	"description": "Display demo in WordPress Playground",
+	"keywords": [ "playground" ],
 	"attributes": {
 		"align": {
 			"type": "string",


### PR DESCRIPTION
This is a minor tweak, but I bet that many people will search for "Playground" or type `/playground` when trying to insert the Playground Block. The addition of the `keyword` property in `block.json` makes this possible. 

Currently, you have to search for "WordPress..." for the block to show up.
