### PR TITLE
WP-NOW: add crypto dependency globally available in node

### DIFF
--- a/packages/wp-now/src/start-server.ts
+++ b/packages/wp-now/src/start-server.ts
@@ -10,6 +10,9 @@ import { NodePHP } from '@php-wasm/node';
 import startWPNow from './wp-now';
 import { output } from './output';
 import { addTrailingSlash } from './add-trailing-slash';
+import crypto from 'crypto';
+
+global.crypto = crypto as Crypto;
 
 function requestBodyToMultipartFormData(json, boundary) {
 	let multipartData = '';


### PR DESCRIPTION
- Closes https://github.com/WordPress/playground-tools/issues/113

<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->

@adamziel fixed the polyfills to run the flag --blueprint without any issues, but installing a plugin throws an error:

`ReferenceError: crypto is not defined`

```
Starting the server......
directory: /Users/macbookpro/proyectos/a8c/playground-tools
mode: playground
php: 8.0
wp: latest
WordPress latest folder already exists. Skipping download.
SQLite folder already exists. Skipping download.
blueprint steps: 2
Blueprint step completed: login
Proceeding without the Notification plugin. Could not install it in wp-admin. The original error was: ReferenceError: crypto is not defined
ReferenceError: crypto is not defined
    at yi (file:///Users/macbookpro/proyectos/a8c/playground-tools/node_modules/@wp-playground/blueprints/index.js:1323:104)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Module.ia [as installPlugin] (file:///Users/macbookpro/proyectos/a8c/playground-tools/node_modules/@wp-playground/blueprints/index.js:1361:36)
    at async a (file:///Users/macbookpro/proyectos/a8c/playground-tools/node_modules/@wp-playground/blueprints/index.js:9339:30)
    at async Object.run (file:///Users/macbookpro/proyectos/a8c/playground-tools/node_modules/@wp-playground/blueprints/index.js:9273:21)
    at async sp (file:///Users/macbookpro/proyectos/a8c/playground-tools/node_modules/@wp-playground/blueprints/index.js:9374:3)
    at async startWPNow (file:///Users/macbookpro/proyectos/a8c/playground-tools/dist/packages/wp-now/main.js:597:5)
    at async startServer (file:///Users/macbookpro/proyectos/a8c/playground-tools/dist/packages/wp-now/main.js:866:42)
    at async Object.handler (file:///Users/macbookpro/proyectos/a8c/playground-tools/dist/packages/wp-now/main.js:1058:25)
Blueprint step completed: installPlugin
Server running at http://localhost:8881
``` 

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The blueprints use `crypto.randomUUID`, but in node we need to import `crypto`.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In this PR I inject the default node library to be globally available.
Other alternatives could be adding the import directly on `@wp-playground/blueprints`, or replace the randomUUID for another function.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->

   * `nvm use && npm install`
   * `npx nx build wp-now`
   * Create a file `b.json` with a blueprint that installs a plugin.
   * `node dist/packages/wp-now/cli.js start --blueprint=b.json`
   * Observe wp-now has started correctly and displays the the notification plugin already installed.

`b.json`
```
{
	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
	"landingPage": "/wp-admin/plugins.php",
	"preferredVersions": {
		"php": "8.0",
		"wp": "latest"
	},
	"steps": [
		{
			"step": "login",
			"username": "admin",
			"password": "password"
		},
		{
			"step": "installPlugin",
			"pluginZipFile": {
				"resource": "wordpress.org/plugins",
				"slug": "notification"
			},
			"options": {
				"activate": true
			}
		}
	]
}
```