### PR TITLE
WP Now: Fix race condition on Windows when downloading WordPress files

### DIFF
--- a/packages/wp-now/src/download.ts
+++ b/packages/wp-now/src/download.ts
@@ -126,6 +126,8 @@ async function downloadFileAndUnzip({
 			);
 		}
 
+		const entryPromises: Promise<unknown>[] = [];
+
 		/**
 		 * Using Parse because Extract is broken:
 		 * https://github.com/WordPress/wordpress-playground/issues/248
@@ -140,11 +142,23 @@ async function downloadFileAndUnzip({
 				 */
 				fs.ensureDirSync(path.dirname(filePath));
 
-				if (entry.type !== 'Directory') {
-					entry.pipe(fs.createWriteStream(filePath));
+				if (entry.type === 'File') {
+					const promise = new Promise((resolve, reject) => {
+						entry
+							.pipe(fs.createWriteStream(filePath))
+							.on('close', resolve)
+							.on('error', reject);
+					});
+					entryPromises.push(promise);
+				} else {
+					entryPromises.push(entry.autodrain().promise());
 				}
 			})
 			.promise();
+
+		// Wait until all entries have been extracted before continuing
+		await Promise.all(entryPromises);
+
 		return { downloaded: true, statusCode };
 	} catch (err) {
 		output?.error(`Error downloading or unzipping ${itemName}:`, err);


### PR DESCRIPTION
## What? / Why?

Waits for wordpress to fully unzip before moving it to `~/.wp-now`

There is a race condition in the code that downloads the latest
WordPress code, unzips it, and places it in `~/.wp-now`.

When I use `wp-now` for the first time on Windows I get the error:
```
Error: EPERM: operation not permitted, rename 'C:\path\to\temp\wordpress' -> 'C:\path\to\.wp-now\wordpress-versions\latest'
```

The error happens in the final step which moves the files. My
understanding is that Macs are more forgiving than Windows when it comes
to renaming/moving files, and it seems that's the issue here. The
current code doesn't wait for the unzipping to finish before moving the
files. And that causes a permission error on Windows.

## How?

This diff waits for each entry in the zip file to finish being written
before progressing on to moving the zip contents. It waits for the
'close' event. Usually it's sufficient to wait for the 'finish' event
before proceeding. However we need to wait for the underlying file
object to be released, and that's the 'close' event.

It also Makes sure we "drain" each entry in the zip file. [The docs for
`unzipper` make a point](https://www.npmjs.com/package/unzipper#parse-zip-file-contents) that each entry in the archive needs to be fully
consumed. I'm not sure how important this actually is for directory
entries, but I've added it for good measure.

<!-- Thanks for contributing to WordPress Playground Tools! -->



<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->



<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->


<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->

1. Check out branch
2. Delete `~/.wp-now/wordpress-versions` to force WordPress to be re-downloaded
3. `nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme`
4. Confirm the spawned server is running and working
5. Confirm `~/.wp-now/wordpress-versions/latest` has been recreated
