### PR TITLE
Support `--wp=nightly` and `--wp=trunk` when starting wp-now

### DIFF
--- a/packages/wp-now/src/download.ts
+++ b/packages/wp-now/src/download.ts
@@ -35,8 +35,11 @@ function httpsGet(url: string, callback: Function) {
 function getWordPressVersionUrl(version = DEFAULT_WORDPRESS_VERSION) {
 	if (!isValidWordPressVersion(version)) {
 		throw new Error(
-			'Unrecognized WordPress version. Please use "latest" or numeric versions such as "6.2", "6.0.1", "6.2-beta1", or "6.2-RC1"'
+			'Unrecognized WordPress version. Please use "latest", "trunk", "nightly", or numeric versions such as "6.2", "6.0.1", "6.2-beta1", or "6.2-RC1"'
 		);
+	}
+	if ( version === 'trunk' || version === 'nightly' ) {
+		return 'https://wordpress.org/nightly-builds/wordpress-latest.zip';
 	}
 	return `https://wordpress.org/wordpress-${version}.zip`;
 }

--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -75,8 +75,8 @@ export default async function startWPNow(
 		});
 		return { php, phpInstances, options };
 	}
-	if ( options.wordPressVersion === 'nightly' ) {
-		options.wordPressVersion = 'trunk';
+	if ( options.wordPressVersion === 'trunk' ) {
+		options.wordPressVersion = 'nightly';
 	}
 	output?.log(`wp: ${options.wordPressVersion}`);
 	await Promise.all([

--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -75,6 +75,9 @@ export default async function startWPNow(
 		});
 		return { php, phpInstances, options };
 	}
+	if ( options.wordPressVersion === 'nightly' ) {
+		options.wordPressVersion = 'trunk';
+	}
 	output?.log(`wp: ${options.wordPressVersion}`);
 	await Promise.all([
 		downloadWordPress(options.wordPressVersion),

--- a/packages/wp-now/src/wp-playground-wordpress/is-valid-wordpress-version.ts
+++ b/packages/wp-now/src/wp-playground-wordpress/is-valid-wordpress-version.ts
@@ -4,6 +4,8 @@
  * The Regex is based on the releases on https://wordpress.org/download/releases/#betas
  * The version string can be one of the following formats:
  * - "latest"
+ * - "trunk"
+ * - "nightly"
  * - "x.y" (x and y are integers) e.g. "6.2"
  * - "x.y.z" (x, y and z are integers) e.g. "6.2.1"
  * - "x.y.z-betaN" (N is an integer) e.g. "6.2.1-beta1"
@@ -14,6 +16,6 @@
  */
 export function isValidWordPressVersion(version: string): boolean {
 	const versionPattern =
-		/^latest$|^(?:(\d+)\.(\d+)(?:\.(\d+))?)((?:-beta(?:\d+)?)|(?:-RC(?:\d+)?))?$/;
+		/^latest$|^trunk$|^nightly$|^(?:(\d+)\.(\d+)(?:\.(\d+))?)((?:-beta(?:\d+)?)|(?:-RC(?:\d+)?))?$/;
 	return versionPattern.test(version);
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/playground-tools/issues/158

## What?

Adds support for `--wp=nightly` and `--wp=trunk` when starting wp-now.

## How?

Returns `'https://wordpress.org/nightly-builds/wordpress-latest.zip'` from `getWordPressVersionUrl()` when `version === 'trunk' || version === 'nightly'`.

## Testing Instructions

1. Run `nx preview wp-now start --path=/Users/danielbachhuber/Desktop --wp=trunk` and verify the latest nightly build is used to launch wp-now.