### PR TITLE
wp-now: Support pretty permalinks without `index.php`

### DIFF
--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -192,7 +192,6 @@ For example, if you run `wp-now start --blueprint=path/to/blueprint-example.json
 -   Running `wp-now start` in 'wp-content' or 'wordpress' mode will produce some empty directories: [WordPress/wordpress-playground#328](https://github.com/WordPress/wordpress-playground/issues/328)
 -   Inline images are broken when site starts on a different port: [WordPress/wordpress-playground#356](https://github.com/WordPress/wordpress-playground/issues/356)
 -   `wp-now` doesn't build or start on Windows: [WordPress/playground-tools#66](https://github.com/WordPress/playground-tools/issues/66), [WordPress/playground-tools#11](https://github.com/WordPress/playground-tools/issues/11)
--   Pretty permalinks aren't yet supported: [WordPress/playground-tools#53](https://github.com/WordPress/playground-tools/issues/53)
 -   It's not possible to set `WP_DEBUG` and other `wp-config.php` constants: [WordPress/playground-tools#17](https://github.com/WordPress/playground-tools/issues/17)
 -   In 'wordpress' mode, `wp-now` can connect to a MySQL database with `define( 'DB_HOST', '127.0.0.1' );`, but `define( 'DB_HOST', 'localhost' );` does not work: [WordPress/wordpress-playground#369](https://github.com/WordPress/wordpress-playground/issues/369)
 -   `wp-now` published versions can appear random: [WordPress/wordpress-playground#357](https://github.com/WordPress/wordpress-playground/issues/357)

--- a/packages/wp-now/src/download.ts
+++ b/packages/wp-now/src/download.ts
@@ -217,4 +217,10 @@ export async function downloadMuPlugins() {
 		);
 	} );`
 	);
+	fs.writeFile(
+		path.join(getWpNowPath(), 'mu-plugins', '1-pretty-permalinks.php'),
+		`<?php
+	// Support permalinks without "index.php"
+	add_filter( 'got_url_rewrite', '__return_true' );`
+	);
 }


### PR DESCRIPTION

## What?

- Resolves #53

#### Before

![wp-now-support-pretty-permalinks--before](https://github.com/WordPress/playground-tools/assets/5352434/05ecbf70-30e1-4f3a-9060-6cdd05c64b15)

#### After

![wp-now-support-pretty-permalinks--after](https://github.com/WordPress/playground-tools/assets/5352434/d58d319c-45a6-4882-a291-674609385269)


## Why?

The admin screen at Settings -&gt; Permalinks prepends `index.php` to all pretty permalinks if the function `got_url_rewrite()` returns false. ([`wp-admin/options-permalink.php`](https://github.com/WordPress/wordpress-develop/blob/aaf778c6a17954fa8a7e9be18009d39e7e606d39/src/wp-admin/options-permalink.php#L79-L81))

There's a filter `got_url_rewrite` to override this behavior. ([`wp-admin/misc.php`](https://github.com/WordPress/wordpress-develop/blob/aaf778c6a17954fa8a7e9be18009d39e7e606d39/src/wp-admin/includes/misc.php#L34-L56))

## How?

Adds a one-line mu-plugin to set the filter to return true. This is done in `downloadMuPlugins()`, which is called during `startWPNow()`.

## Testing Instructions

1. Check out the branch.
2. Run `npx nx preview wp-now start`
3. Visit [`http://localhost:8881/wp-admin/options-permalink.php`](http://localhost:8881/wp-admin/options-permalink.php)
4. Confirm that pretty permalinks do not have URL base `index.php`
