### PR TITLE
Add Playground footer

### DIFF
--- a/packages/interactive-code-block/project.json
+++ b/packages/interactive-code-block/project.json
@@ -14,7 +14,6 @@
 				"cwd": "dist/packages",
 				"commands": [
 					"cp ../../packages/interactive-code-block/README.md ./interactive-code-block/",
-					"rm interactive-code-block/assets/php_5*",
 					"rm interactive-code-block/assets/php_7_0*",
 					"rm interactive-code-block/assets/php_7_1*",
 					"rm interactive-code-block/assets/php_7_2*",

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -449,12 +449,12 @@ export default function PlaygroundPreview({
 				></iframe>
 			</main>
 			<footer className="demo-footer">
-				<span className="demo-footer__powered">Powered by </span>
 				<a
 					href="https://w.org/playground"
 					className="demo-footer__link"
 					target="_blank"
 				>
+					<span className="demo-footer__powered">Powered by</span>
 					<Icon className="demo-footer__icon" icon={wordpress} />
 					<span className="demo-footer__link-text">
 						WordPress Playground

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -449,9 +449,16 @@ export default function PlaygroundPreview({
 				></iframe>
 			</main>
 			<footer className="demo-footer">
-				<a href="https://w.org/playground" target="_blank">
-					<span>Powered by WordPress Playground</span>
-					<Icon icon={wordpress} />
+				<span className="demo-footer__powered">Powered by </span>
+				<a
+					href="https://w.org/playground"
+					className="demo-footer__link"
+					target="_blank"
+				>
+					<Icon className="demo-footer__icon" icon={wordpress} />
+					<span className="demo-footer__link-text">
+						WordPress Playground
+					</span>
 				</a>
 			</footer>
 		</>

--- a/packages/wordpress-playground-block/src/style.scss
+++ b/packages/wordpress-playground-block/src/style.scss
@@ -50,13 +50,15 @@
 		}
 		.demo-footer__link {
 			.demo-footer__icon {
-				margin: 0 $spacing/2 0 $spacing;
+				margin: 0 $spacing/2;
 				fill: $color;
 				vertical-align: middle;
 			}
 			&:hover {
-				.demo-footer__link-text {
+				.demo-footer__link-text,
+				.demo-footer__powered {
 					color: $hover-color;
+					opacity: 1;
 				}
 				.demo-footer__icon {
 					fill: $hover-color;

--- a/packages/wordpress-playground-block/src/style.scss
+++ b/packages/wordpress-playground-block/src/style.scss
@@ -1,7 +1,5 @@
 .wp-block-wordpress-playground-playground {
 	border-radius: 10px;
-	overflow: hidden;
-	box-shadow: #03254b47 0px 12px 50px 0px;
 
 	* {
 		box-sizing: border-box;
@@ -26,29 +24,29 @@
 	.demo-container {
 		display: flex;
 		flex-wrap: wrap;
+		box-shadow: #03254b47 0px 12px 50px 0px;
+		overflow: hidden;
 	}
 
 	.demo-footer {
 		$spacing: 4px;
-		$background-color: #1d2327;
-		$color: #f0f0f1;
-		$hover-color: #72aee6;
+		$color: var(--wp--preset--color--contrast);
+		$hover-color: var(--wp--preset--color--vivid-cyan-blue);
 
 		padding: $spacing 2 * $spacing;
-		background-color: $background-color;
 		text-align: center;
 		.demo-footer__link,
 		.demo-footer__powered,
 		.demo-footer__link-text {
 			color: $color;
 			text-decoration: none;
-			font-size: 12px;
+			font-size: 13px;
 			line-height: 1;
 			display: inline-block;
 			vertical-align: middle;
 		}
 		.demo-footer__powered {
-			color: rgba(240, 246, 252, 0.7);
+			opacity: 0.7;
 		}
 		.demo-footer__link {
 			.demo-footer__icon {

--- a/packages/wordpress-playground-block/src/style.scss
+++ b/packages/wordpress-playground-block/src/style.scss
@@ -28,6 +28,39 @@
 		flex-wrap: wrap;
 	}
 
+	.demo-footer {
+		$spacing: 4px;
+		$background-color: #1d2327;
+		$color: rgba(240, 246, 252, .7);
+		$hover-color: #72aee6;
+
+		padding: $spacing 2*$spacing;
+		background-color: $background-color;
+		> a {
+			span {
+				color: $color;
+				text-decoration: none;
+				font-size: 14px;
+				line-height: 1;
+				display: inline-block;
+				vertical-align: middle;
+			}
+			> svg {
+				margin-right: $spacing;
+				fill: $color;
+				vertical-align: middle;
+			}
+			&:hover {
+				span {
+					color: $hover-color;
+				}
+				> svg {
+					fill: $hover-color;
+				}
+			}
+		}
+	}
+
 	.code-container {
 		flex: 1;
 		display: flex;

--- a/packages/wordpress-playground-block/src/style.scss
+++ b/packages/wordpress-playground-block/src/style.scss
@@ -28,6 +28,39 @@
 		flex-wrap: wrap;
 	}
 
+	.demo-footer {
+		$spacing: 4px;
+		$background-color: #1d2327;
+		$color: rgba(240, 246, 252, 0.7);
+		$hover-color: #72aee6;
+
+		padding: $spacing 2 * $spacing;
+		background-color: $background-color;
+		> a {
+			span {
+				color: $color;
+				text-decoration: none;
+				font-size: 14px;
+				line-height: 1;
+				display: inline-block;
+				vertical-align: middle;
+			}
+			> svg {
+				margin-right: $spacing;
+				fill: $color;
+				vertical-align: middle;
+			}
+			&:hover {
+				span {
+					color: $hover-color;
+				}
+				> svg {
+					fill: $hover-color;
+				}
+			}
+		}
+	}
+
 	.code-container {
 		flex: 1;
 		display: flex;

--- a/packages/wordpress-playground-block/src/style.scss
+++ b/packages/wordpress-playground-block/src/style.scss
@@ -31,31 +31,36 @@
 	.demo-footer {
 		$spacing: 4px;
 		$background-color: #1d2327;
-		$color: rgba(240, 246, 252, 0.7);
+		$color: #f0f0f1;
 		$hover-color: #72aee6;
 
 		padding: $spacing 2 * $spacing;
 		background-color: $background-color;
-		text-align: right;
-		> a {
-			span {
-				color: $color;
-				text-decoration: none;
-				font-size: 12px;
-				line-height: 1;
-				display: inline-block;
-				vertical-align: middle;
-			}
-			> svg {
-				margin-left: $spacing;
+		text-align: center;
+		.demo-footer__link,
+		.demo-footer__powered,
+		.demo-footer__link-text {
+			color: $color;
+			text-decoration: none;
+			font-size: 12px;
+			line-height: 1;
+			display: inline-block;
+			vertical-align: middle;
+		}
+		.demo-footer__powered {
+			color: rgba(240, 246, 252, 0.7);
+		}
+		.demo-footer__link {
+			.demo-footer__icon {
+				margin: 0 $spacing/2 0 $spacing;
 				fill: $color;
 				vertical-align: middle;
 			}
 			&:hover {
-				span {
+				.demo-footer__link-text {
 					color: $hover-color;
 				}
-				> svg {
+				.demo-footer__icon {
 					fill: $hover-color;
 				}
 			}


### PR DESCRIPTION
Fixes #145

<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

This PR adds a footer to the Playground block.

![Screenshot 2024-02-26 at 20 54 48](https://github.com/WordPress/playground-tools/assets/1199991/11ff52b7-3ddf-4d62-8611-444da691da6c)

## Why?

The footer should promote WordPress Playground and hopefully increase adoption. 

## How?

By adding a footer element to the block and adding a link to WordPress Playground.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
1. Check out the branch.
2. Start dev site `nx dev wordpress-playground-block`
3. On the dev site create a new post and add the WordPress Playground block
4. Confirm that the footer is loaded in the admin menu
5. Save the post and open it
6. Confirm that the footer is loaded on the post page

