### PR TITLE
Fix app plugin check issues

### DIFF
--- a/packages/playground/.editorconfig
+++ b/packages/playground/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-trim_trailing_whitespace = true
-insert_final_newline     = true
-indent_style             = tab
-indent_size              = 4
-end_of_line              = lf
-charset                  = utf-8

--- a/packages/playground/README.txt
+++ b/packages/playground/README.txt
@@ -1,13 +1,16 @@
-=== WordPress Playground ===
+=== Playground ===
 Contributors: wordpressdotorg, antoniosejas, berislavgrgicak, zieladam
 Tags: playground, staging, sandbox
 Requires at least: 6.0
 Tested up to: 6.4
-Stable tag: 0.1.0
+Stable tag: 0.0.1
 Requires PHP: 7.0
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
-Early preview: Enables running a sandbox of your site using WordPress Playground (https://github.com/WordPress/wordpress-playground)
+
+= Short description =
+
+Enables running a sandbox of your site using WordPress Playground (https://github.com/WordPress/wordpress-playground)
 
 == Description ==
 

--- a/packages/playground/playground.php
+++ b/packages/playground/playground.php
@@ -12,7 +12,6 @@ namespace WordPress\Playground;
 defined('ABSPATH') || exit;
 
 const PLAYGROUND_ADMIN_PAGE_SLUG = 'playground';
-const TRANSLATE_DOMAIN = 'playground';
 const ADMIN_PAGE_CAPABILITY = 'manage_options';
 
 global $wp_version;
@@ -61,6 +60,7 @@ function enqueue_scripts($current_screen_id)
 			'playground_remote_url',
 			esc_url('https://playground.wordpress.net/remote.html'),
 		),
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		'pluginSlug' => isset($_GET['pluginSlug']) ? $_GET['pluginSlug'] : false,
 	]);
 	wp_enqueue_script('playground');
@@ -98,9 +98,12 @@ function plugins_loaded()
 		return;
 	}
 
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	if (!isset($_GET['page']) || PLAYGROUND_ADMIN_PAGE_SLUG !== $_GET['page']) {
 		return;
 	}
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	if (!isset($_GET['download'])) {
 		return;
 	}
@@ -130,6 +133,7 @@ function plugin_menu()
  */
 function render_playground_page()
 {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	if (isset($_GET['download'])) {
 		return;
 	}
@@ -145,7 +149,8 @@ function render_playground_page()
  */
 function plugin_install_action_links($action_links, $plugin)
 {
-	$retUrl = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) . urlencode('?' . http_build_query($_GET));
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$retUrl = wp_parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) . urlencode('?' . http_build_query($_GET));
 
 	$preview_url = add_query_arg(
 		[
@@ -167,7 +172,7 @@ function plugin_install_action_links($action_links, $plugin)
 			)
 		),
 		esc_attr($plugin['name']),
-		__('Preview Now', TRANSLATE_DOMAIN)
+		__('Preview Now', 'playground')
 	);
 
 	array_unshift($action_links, $preview_button);

--- a/packages/playground/src/playground-db.php
+++ b/packages/playground/src/playground-db.php
@@ -1,5 +1,5 @@
 <?php
-
+// phpcs:ignoreFile WordPress.DB.DirectDatabaseQuery.DirectQuery
 namespace WordPress\Playground;
 
 defined('ABSPATH') || exit;
@@ -49,10 +49,8 @@ function zip_database($zip)
 
 	foreach ($tables as $table) {
 		$records = $wpdb->get_results(
-			sprintf(
-				'SELECT * FROM %s',
-				$wpdb->quote_identifier($table)
-			),
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			sprintf('SELECT * FROM %s', $wpdb->quote_identifier($table)),
 			ARRAY_A
 		);
 
@@ -100,6 +98,7 @@ function dump_db_schema($table)
 {
 	global $wpdb;
 	$schema = $wpdb->get_row(
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		sprintf('SHOW CREATE TABLE %s', $wpdb->quote_identifier($table)),
 		ARRAY_A
 	);

--- a/packages/playground/src/playground-zip.php
+++ b/packages/playground/src/playground-zip.php
@@ -33,7 +33,7 @@ function zip_wp_content($zip)
 		}
 
 		$file = apply_filters('playground_exported_file', $file);
-		if ( false !== $file ) {
+		if (false === $file) {
 			continue;
 		}
 		$zip->addFileFromPath(
@@ -51,7 +51,7 @@ function zip_collect()
 	$options = new Archive();
 	$options->setSendHttpHeaders(true);
 	$zip = new ZipStream(
-		'playground-package-' . date('Y-m-d_H-i-s') . '.zip',
+		'playground-package-' . gmdate('Y-m-d_H-i-s') . '.zip',
 		$options
 	);
 

--- a/packages/playground/templates/playground-page.php
+++ b/packages/playground/templates/playground-page.php
@@ -9,17 +9,20 @@ defined('ABSPATH') || exit;
     <div id="wp-playground-toolbar">
         <span>
             <?php
-            printf(
-                __(
-                    'WordPress Playground preview for %s',
-                    TRANSLATE_DOMAIN
-                ),
-                get_bloginfo('name')
+            echo esc_attr(
+                sprintf(
+                    // translators: %s: Site name.
+                    __(
+                        'WordPress Playground preview for %s',
+                        'playground'
+                    ),
+                    get_bloginfo('name')
+                )
             );
             ?>
         </span>
-        <a href="<?php echo admin_url('plugin-install.php'); ?>" id="goBack">
-            <?php _e('Go Back', TRANSLATE_DOMAIN); ?>
+        <a href="<?php echo esc_url(admin_url('plugin-install.php')); ?>" id="goBack">
+            <?php esc_attr_e('Go Back', 'playground'); ?>
         </a>
     </div>
     <div id="wp-playground-main-area">


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

Makes the Playground plugin [pass plugin checks](https://wordpress.org/plugins/plugin-check/)

## Why?

We want to publish this plugin to WordPress.org.

## How?

By addressing all errors produced by the [Plugin check](https://wordpress.org/plugins/plugin-check/) plugin
 
## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
1. Check out the branch.
2. Install Playground on a site
3. Follow the [Usage instructions](https://github.com/WordPress/playground-tools/compare/fix/playground-plugin-checks?expand=1#diff-9068e80f7f470944cdbffff0e7ceaccfe5bdd11283038698638b562b5410c62bL20) and ensure they work
4. Optionally install [Plugin check](https://wordpress.org/plugins/plugin-check/) and confirm all tests pass

![Screenshot 2024-03-05 at 12 53 09](https://github.com/WordPress/playground-tools/assets/1199991/7e9f86c5-9937-477a-82cd-6987111a432b)

