### PR TITLE
Playground block: Import the client library from playground.wordpres.net

### DIFF
--- a/packages/wordpress-playground-block/src/components/playground-preview/download-zipped-plugin.ts
+++ b/packages/wordpress-playground-block/src/components/playground-preview/download-zipped-plugin.ts
@@ -1,4 +1,8 @@
-import { PlaygroundClient, phpVar } from '@wp-playground/client';
+import {
+	type PlaygroundClient,
+	phpVar,
+	// @ts-ignore
+} from 'https://playground.wordpress.net/client/index.js';
 
 export default async function downloadZippedPlugin(client: PlaygroundClient) {
 	const docroot = await client.documentRoot;

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -9,9 +9,10 @@ import { json } from '@codemirror/lang-json';
 import { php } from '@codemirror/lang-php';
 import {
 	startPlaygroundWeb,
-	PlaygroundClient,
+	type PlaygroundClient,
 	phpVar,
-} from '@wp-playground/client';
+	// @ts-ignore
+} from 'https://playground.wordpress.net/client/index.js';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import {

--- a/packages/wordpress-playground-block/src/components/playground-preview/write-plugin-files.ts
+++ b/packages/wordpress-playground-block/src/components/playground-preview/write-plugin-files.ts
@@ -1,5 +1,6 @@
 import type { EditorFile } from '../../index';
-import { PlaygroundClient } from '@wp-playground/client';
+// @ts-ignore
+import { PlaygroundClient } from 'https://playground.wordpress.net/client/index.js';
 import { activatePlugin } from '@wp-playground/blueprints';
 
 export const writePluginFiles = async (


### PR DESCRIPTION
Importing the library from an npm package requires updating the plugin each time a new version is released. This ensures the block always uses the latest version.

## Testing instructions

Run the block locally with `nx dev wordpress-playground-block` and confirm it works as expected. Then build it with `nx build wordpress-playground-block`, install on a WordPress site, and confirm the built version also works.
