### PR TITLE
Playground Block: Remove @wp-playground/client and @wp-playground/blueprints dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
 				"@php-wasm/web": "0.6.7",
 				"@uiw/react-codemirror": "^4.21.20",
 				"@wp-playground/blueprints": "0.6.7",
-				"@wp-playground/client": "0.6.7",
 				"classnames": "^2.3.2",
 				"comlink": "^4.4.1",
 				"compressible": "2.0.18",
@@ -17950,15 +17949,6 @@
 			"version": "0.6.7",
 			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-0.6.7.tgz",
 			"integrity": "sha512-/nJAq+ftPqb3naV3DEZaLWnbKNkRgL9+U8p7Ai1M0bpyCUPW0lQ0kVbr+oaJaigjuo2Qhb5txcovGF3XLL9awA==",
-			"engines": {
-				"node": ">=18.18.2",
-				"npm": ">=8.11.0"
-			}
-		},
-		"node_modules/@wp-playground/client": {
-			"version": "0.6.7",
-			"resolved": "https://registry.npmjs.org/@wp-playground/client/-/client-0.6.7.tgz",
-			"integrity": "sha512-0IOo+rSh5oxaUfMSEWn5rnKQAmaff5ZDFZYcVc1lS8Ia8oysCiHfKqLBulbCwxw0a94YLjbOouo7JC4JhoHBiw==",
 			"engines": {
 				"node": ">=18.18.2",
 				"npm": ">=8.11.0"
@@ -48358,12 +48348,6 @@
 			"name": "@wp-playground/blueprints",
 			"version": "0.1.51",
 			"extraneous": true
-		},
-		"packages/playground/client": {
-			"name": "@wp-playground/client",
-			"version": "0.1.51",
-			"extraneous": true,
-			"license": "GPL-2.0-or-later"
 		},
 		"packages/playground/compile-wordpress": {
 			"name": "@wp-playground/compile-wordpress",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
 		"@php-wasm/web": "0.6.7",
 		"@uiw/react-codemirror": "^4.21.20",
 		"@wp-playground/blueprints": "0.6.7",
-		"@wp-playground/client": "0.6.7",
 		"classnames": "^2.3.2",
 		"comlink": "^4.4.1",
 		"compressible": "2.0.18",

--- a/packages/interactive-code-block/vite.config.ts
+++ b/packages/interactive-code-block/vite.config.ts
@@ -73,7 +73,6 @@ export default defineConfig({
 			preserveEntrySignatures: 'strict',
 			plugins: [react()],
 			input: {
-				['playground-client']: '@wp-playground/client',
 				['comlink']: 'comlink/dist/esm/comlink.mjs',
 				['editor']: path('src/lib/block/editor.tsx'),
 				['view']: path('src/lib/block/view.ts'),

--- a/packages/wordpress-playground-block/src/components/playground-preview/write-plugin-files.ts
+++ b/packages/wordpress-playground-block/src/components/playground-preview/write-plugin-files.ts
@@ -1,7 +1,9 @@
 import type { EditorFile } from '../../index';
-// @ts-ignore
-import { PlaygroundClient } from 'https://playground.wordpress.net/client/index.js';
-import { activatePlugin } from '@wp-playground/blueprints';
+import {
+	PlaygroundClient,
+	activatePlugin,
+	// @ts-ignore
+} from 'https://playground.wordpress.net/client/index.js';
 
 export const writePluginFiles = async (
 	client: PlaygroundClient,

--- a/packages/wordpress-playground-block/src/index.ts
+++ b/packages/wordpress-playground-block/src/index.ts
@@ -1,5 +1,10 @@
 import { registerBlockType } from '@wordpress/blocks';
-import { Component, createElement, useEffect, useState } from '@wordpress/element';
+import {
+	Component,
+	createElement,
+	useEffect,
+	useState,
+} from '@wordpress/element';
 
 import metadata from './block.json';
 import './style.scss';
@@ -43,7 +48,7 @@ export type Attributes = {
 const EditComponentPromise = import('./edit');
 let EditComponent: Component | undefined = undefined;
 EditComponentPromise.then((module) => {
-	EditComponent = module.default as any as Component;	
+	EditComponent = module.default as any as Component;
 });
 
 // @ts-ignore
@@ -58,7 +63,9 @@ registerBlockType<Attributes>(metadata.name, {
 			}
 		}, []);
 		if (!isLoaded) {
-			return createElement('span', {}, ['Loading the WordPress Playground Block...']);
+			return createElement('span', {}, [
+				'Loading the WordPress Playground Block...',
+			]);
 		}
 		return createElement(EditComponent as any, props);
 	},


### PR DESCRIPTION
This PR Updates makes the WordPress Playground Block rely on the client library imported from https://playground.wordpress.net/client/index.js. This fixes the Playground block in safari:

https://github.com/WordPress/playground-tools/issues/176

 ## Testing instructions

Confirm the CI checks are green
