### PR TITLE
Playground block: Fix button CSS and code editor max-height

### DIFF
--- a/packages/wordpress-playground-block/src/style.scss
+++ b/packages/wordpress-playground-block/src/style.scss
@@ -6,6 +6,10 @@
 	}
 
 	.wordpress-playground-block-button {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+
 		font-size: 16px;
 		padding: 6px 12px;
 		cursor: pointer;
@@ -137,7 +141,7 @@
 	.cm-editor {
 		width: 100%;
 		height: 100%;
-		max-height: min(450px, 50vh);
+		max-height: min(450px, 80vh);
 	}
 
 	.cm-content {


### PR DESCRIPTION
### Change 1 – fixes "Remove file" Button CSS

**Before:**

<img width="200" src="https://github.com/WordPress/playground-tools/assets/205419/cf270dc6-9fd1-48a9-943f-ad8f4716886f" >

**After:**

<img width="200" src="https://github.com/WordPress/playground-tools/assets/205419/bc6b3126-71d9-4728-a237-dd9d6d604f34" >

### Change 2 – improve code editor max-height

Code editor used to occupy to little vertical space when the window height was low. This PR increases the 50vh constraint to 80vh.
