### PR TITLE
wordpress-playground-block: Require Activation Before Loading Playground Iframe

### DIFF
--- a/packages/wordpress-playground-block/src/block.json
+++ b/packages/wordpress-playground-block/src/block.json
@@ -98,6 +98,10 @@
 		},
 		"blueprint": {
 			"type": "string"
+		},
+		"requireLivePreviewActivation": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"supports": {

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -279,7 +279,13 @@ export default function PlaygroundPreview({
 			const lastPath = await playgroundClientRef.current!.getCurrentURL();
 			await playgroundClientRef.current!.goTo(getRefreshPath(lastPath));
 		}
-		doHandleRun();
+
+		if (!isLivePreviewActivated) {
+			// Activate and let the code be run by Playground init
+			setLivePreviewActivated(true);
+		} else {
+			doHandleRun();
+		}
 	}, [reinstallEditedPlugin]);
 
 	const keymapExtension = useMemo(
@@ -300,6 +306,10 @@ export default function PlaygroundPreview({
 		'is-full-width': !codeEditorSideBySide,
 		'is-half-width': codeEditorSideBySide,
 	});
+
+	const iframeCreationWarning = 
+		'This button creates an iframe containing a full WordPress website ' +
+		'which may be a challenge for screen readers.';
 
 	return (
 		<>
@@ -445,6 +455,11 @@ export default function PlaygroundPreview({
 									handleReRunCode();
 								}}
 								className="wordpress-playground-run-button"
+								aria-description={
+									requireLivePreviewActivation
+										? iframeCreationWarning
+										: undefined
+								}
 							>
 								Run
 							</Button>
@@ -457,11 +472,7 @@ export default function PlaygroundPreview({
 							className="wordpress-playground-activate-button"
 							variant="primary"
 							onClick={() => setLivePreviewActivated(true)}
-							aria-description={
-								'This button creates an iframe containing ' +
-								'a full WordPress website which may be ' +
-								'a challenge for screen readers.'
-							}
+							aria-description={iframeCreationWarning}
 						>
 							Activate Live Preview
 						</Button>

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -307,7 +307,7 @@ export default function PlaygroundPreview({
 		'is-half-width': codeEditorSideBySide,
 	});
 
-	const iframeCreationWarning = 
+	const iframeCreationWarning =
 		'This button creates an iframe containing a full WordPress website ' +
 		'which may be a challenge for screen readers.';
 

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -301,167 +301,169 @@ export default function PlaygroundPreview({
 	return (
 		<>
 			<main className="demo-container">
+				{codeEditor && (
+					<div className={codeContainerClass}>
+						<div className="file-tabs">
+							{files.map((file, index) => (
+								<Button
+									key={file.name}
+									variant="primary"
+									className={`file-tab ${
+										index === activeFileIndex &&
+										'file-tab-active'
+									}`}
+									onClick={() => {
+										setActiveFileIndex(index);
+									}}
+									onDoubleClick={() => {
+										setEditFileNameModalOpen(true);
+									}}
+								>
+									{file.name}
+								</Button>
+							))}
+							{showAddNewFile && (
+								<Button
+									variant="secondary"
+									className="file-tab file-tab-extra"
+									onClick={() => setNewFileModalOpen(true)}
+								>
+									<Icon icon={plus} />
+								</Button>
+							)}
+							<Button
+								variant="secondary"
+								className="file-tab file-tab-extra"
+								onClick={() => {
+									if (playgroundClientRef.current) {
+										downloadZippedPlugin(
+											playgroundClientRef.current
+										);
+									}
+								}}
+							>
+								<Icon icon={download} />
+							</Button>
+							{isNewFileModalOpen && (
+								<FileNameModal
+									title="Create new file"
+									onRequestClose={() =>
+										setNewFileModalOpen(false)
+									}
+									onSave={(newFileName) => {
+										addFile({
+											name: newFileName,
+											contents: '',
+										});
+										setActiveFileIndex(files.length);
+										setNewFileModalOpen(false);
+									}}
+								/>
+							)}
+						</div>
+						<div className="code-editor-wrapper">
+							<ReactCodeMirror
+								value={activeFile.contents}
+								extensions={[
+									keymapExtension,
+									EditorView.lineWrapping,
+									...getLanguageExtensions(
+										currentFileExtension || 'js'
+									),
+								]}
+								readOnly={codeEditorReadOnly}
+								onChange={(value) =>
+									updateFile((file) => ({
+										...file,
+										contents: value,
+									}))
+								}
+							/>
+						</div>
+						<div className="actions-bar">
+							{showFileControls ? (
+								<div className="file-actions">
+									{!activeFile && (
+										<button
+											type="button"
+											onClick={() => {
+												setEditFileNameModalOpen(true);
+											}}
+											className="wordpress-playground-block-button button-non-destructive"
+										>
+											<Icon icon={edit} /> Edit file name
+										</button>
+									)}
+									{!isErrorLogFile(activeFile) &&
+										files.filter(
+											(file) => !isErrorLogFile(file)
+										).length > 1 && (
+											<button
+												type="button"
+												className="wordpress-playground-block-button button-destructive"
+												onClick={() => {
+													setActiveFileIndex(0);
+													removeFile(activeFileIndex);
+												}}
+											>
+												<Icon
+													icon={cancelCircleFilled}
+												/>{' '}
+												Remove file
+											</button>
+										)}
+									{isEditFileNameModalOpen && (
+										<FileNameModal
+											title="Edit file name"
+											initialFilename={
+												files[activeFileIndex].name
+											}
+											onRequestClose={() =>
+												setEditFileNameModalOpen(false)
+											}
+											onSave={(fileName) => {
+												updateFile((file) => ({
+													...file,
+													name: fileName,
+												}));
+												setEditFileNameModalOpen(false);
+											}}
+										/>
+									)}
+								</div>
+							) : (
+								<div className="file-actions"></div>
+							)}
+							<Button
+								variant="primary"
+								icon="controls-play"
+								iconPosition="right"
+								onClick={() => {
+									handleReRunCode();
+								}}
+								className="wordpress-playground-run-button"
+							>
+								Run
+							</Button>
+						</div>
+					</div>
+				)}
 				{!isActivated && (
-					<Button
-						className="wordpress-playground-activate-button"
-						onClick={() => setActivated(true)}
-					>Activate WordPress Playground</Button>
+					<div className="playground-activation-placeholder">
+						<Button
+							className="wordpress-playground-activate-button"
+							onClick={() => setActivated(true)}
+						>
+							Activate Live Preview
+						</Button>
+					</div>
 				)}
 				{isActivated && (
-					<>
-					    {codeEditor && (
-					    	<div className={codeContainerClass}>
-					    		<div className="file-tabs">
-					    			{files.map((file, index) => (
-					    				<Button
-					    					key={file.name}
-					    					variant="primary"
-					    					className={`file-tab ${
-					    						index === activeFileIndex &&
-					    						'file-tab-active'
-					    					}`}
-					    					onClick={() => {
-					    						setActiveFileIndex(index);
-					    					}}
-					    					onDoubleClick={() => {
-					    						setEditFileNameModalOpen(true);
-					    					}}
-					    				>
-					    					{file.name}
-					    				</Button>
-					    			))}
-					    			{showAddNewFile && (
-					    				<Button
-					    					variant="secondary"
-					    					className="file-tab file-tab-extra"
-					    					onClick={() => setNewFileModalOpen(true)}
-					    				>
-					    					<Icon icon={plus} />
-					    				</Button>
-					    			)}
-					    			<Button
-					    				variant="secondary"
-					    				className="file-tab file-tab-extra"
-					    				onClick={() => {
-					    					if (playgroundClientRef.current) {
-					    						downloadZippedPlugin(
-					    							playgroundClientRef.current
-					    						);
-					    					}
-					    				}}
-					    			>
-					    				<Icon icon={download} />
-					    			</Button>
-					    			{isNewFileModalOpen && (
-					    				<FileNameModal
-					    					title="Create new file"
-					    					onRequestClose={() =>
-					    						setNewFileModalOpen(false)
-					    					}
-					    					onSave={(newFileName) => {
-					    						addFile({
-					    							name: newFileName,
-					    							contents: '',
-					    						});
-					    						setActiveFileIndex(files.length);
-					    						setNewFileModalOpen(false);
-					    					}}
-					    				/>
-					    			)}
-					    		</div>
-					    		<div className="code-editor-wrapper">
-					    			<ReactCodeMirror
-					    				value={activeFile.contents}
-					    				extensions={[
-					    					keymapExtension,
-					    					EditorView.lineWrapping,
-					    					...getLanguageExtensions(
-					    						currentFileExtension || 'js'
-					    					),
-					    				]}
-					    				readOnly={codeEditorReadOnly}
-					    				onChange={(value) =>
-					    					updateFile((file) => ({
-					    						...file,
-					    						contents: value,
-					    					}))
-					    				}
-					    			/>
-					    		</div>
-					    		<div className="actions-bar">
-					    			{showFileControls ? (
-					    				<div className="file-actions">
-					    					{!activeFile && (
-					    						<button
-					    							type="button"
-					    							onClick={() => {
-					    								setEditFileNameModalOpen(true);
-					    							}}
-					    							className="wordpress-playground-block-button button-non-destructive"
-					    						>
-					    							<Icon icon={edit} /> Edit file name
-					    						</button>
-					    					)}
-					    					{!isErrorLogFile(activeFile) &&
-					    						files.filter(
-					    							(file) => !isErrorLogFile(file)
-					    						).length > 1 && (
-					    							<button
-					    								type="button"
-					    								className="wordpress-playground-block-button button-destructive"
-					    								onClick={() => {
-					    									setActiveFileIndex(0);
-					    									removeFile(activeFileIndex);
-					    								}}
-					    							>
-					    								<Icon
-					    									icon={cancelCircleFilled}
-					    								/>{' '}
-					    								Remove file
-					    							</button>
-					    						)}
-					    					{isEditFileNameModalOpen && (
-					    						<FileNameModal
-					    							title="Edit file name"
-					    							initialFilename={
-					    								files[activeFileIndex].name
-					    							}
-					    							onRequestClose={() =>
-					    								setEditFileNameModalOpen(false)
-					    							}
-					    							onSave={(fileName) => {
-					    								updateFile((file) => ({
-					    									...file,
-					    									name: fileName,
-					    								}));
-					    								setEditFileNameModalOpen(false);
-					    							}}
-					    						/>
-					    					)}
-					    				</div>
-					    			) : (
-					    				<div className="file-actions"></div>
-					    			)}
-					    			<Button
-					    				variant="primary"
-					    				icon="controls-play"
-					    				iconPosition="right"
-					    				onClick={() => {
-					    					handleReRunCode();
-					    				}}
-					    				className="wordpress-playground-run-button"
-					    			>
-					    				Run
-					    			</Button>
-					    		</div>
-					    	</div>
-					    )}
-					    <iframe
-					    	key="playground-iframe"
-					    	ref={iframeRef}
-					    	className="playground-iframe"
-					    ></iframe>
-					</>
+					<iframe
+						key="playground-iframe"
+						ref={iframeRef}
+						className="playground-iframe"
+					></iframe>
 				)}
 			</main>
 			<footer className="demo-footer">

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -111,8 +111,9 @@ export default function PlaygroundPreview({
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 	const playgroundClientRef = useRef<PlaygroundClient | null>(null);
 
-	const [isLivePreviewActivated, setLivePreviewActivated] =
-		useState(!requireLivePreviewActivation);
+	const [isLivePreviewActivated, setLivePreviewActivated] = useState(
+		!requireLivePreviewActivation
+	);
 	const [currentPostId, setCurrentPostId] = useState(0);
 	const [isNewFileModalOpen, setNewFileModalOpen] = useState(false);
 	const [isEditFileNameModalOpen, setEditFileNameModalOpen] = useState(false);

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -110,6 +110,7 @@ export default function PlaygroundPreview({
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 	const playgroundClientRef = useRef<PlaygroundClient | null>(null);
 
+	const [isActivated, setActivated] = useState(false);
 	const [currentPostId, setCurrentPostId] = useState(0);
 	const [isNewFileModalOpen, setNewFileModalOpen] = useState(false);
 	const [isEditFileNameModalOpen, setEditFileNameModalOpen] = useState(false);
@@ -129,6 +130,9 @@ export default function PlaygroundPreview({
 
 	useEffect(() => {
 		async function initPlayground() {
+			if (!isActivated) {
+				return;
+			}
 			if (!iframeRef.current) {
 				return;
 			}
@@ -219,6 +223,7 @@ export default function PlaygroundPreview({
 
 		initPlayground();
 	}, [
+		isActivated,
 		blueprint,
 		blueprintUrl,
 		configurationSource,
@@ -296,158 +301,168 @@ export default function PlaygroundPreview({
 	return (
 		<>
 			<main className="demo-container">
-				{codeEditor && (
-					<div className={codeContainerClass}>
-						<div className="file-tabs">
-							{files.map((file, index) => (
-								<Button
-									key={file.name}
-									variant="primary"
-									className={`file-tab ${
-										index === activeFileIndex &&
-										'file-tab-active'
-									}`}
-									onClick={() => {
-										setActiveFileIndex(index);
-									}}
-									onDoubleClick={() => {
-										setEditFileNameModalOpen(true);
-									}}
-								>
-									{file.name}
-								</Button>
-							))}
-							{showAddNewFile && (
-								<Button
-									variant="secondary"
-									className="file-tab file-tab-extra"
-									onClick={() => setNewFileModalOpen(true)}
-								>
-									<Icon icon={plus} />
-								</Button>
-							)}
-							<Button
-								variant="secondary"
-								className="file-tab file-tab-extra"
-								onClick={() => {
-									if (playgroundClientRef.current) {
-										downloadZippedPlugin(
-											playgroundClientRef.current
-										);
-									}
-								}}
-							>
-								<Icon icon={download} />
-							</Button>
-							{isNewFileModalOpen && (
-								<FileNameModal
-									title="Create new file"
-									onRequestClose={() =>
-										setNewFileModalOpen(false)
-									}
-									onSave={(newFileName) => {
-										addFile({
-											name: newFileName,
-											contents: '',
-										});
-										setActiveFileIndex(files.length);
-										setNewFileModalOpen(false);
-									}}
-								/>
-							)}
-						</div>
-						<div className="code-editor-wrapper">
-							<ReactCodeMirror
-								value={activeFile.contents}
-								extensions={[
-									keymapExtension,
-									EditorView.lineWrapping,
-									...getLanguageExtensions(
-										currentFileExtension || 'js'
-									),
-								]}
-								readOnly={codeEditorReadOnly}
-								onChange={(value) =>
-									updateFile((file) => ({
-										...file,
-										contents: value,
-									}))
-								}
-							/>
-						</div>
-						<div className="actions-bar">
-							{showFileControls ? (
-								<div className="file-actions">
-									{!activeFile && (
-										<button
-											type="button"
-											onClick={() => {
-												setEditFileNameModalOpen(true);
-											}}
-											className="wordpress-playground-block-button button-non-destructive"
-										>
-											<Icon icon={edit} /> Edit file name
-										</button>
-									)}
-									{!isErrorLogFile(activeFile) &&
-										files.filter(
-											(file) => !isErrorLogFile(file)
-										).length > 1 && (
-											<button
-												type="button"
-												className="wordpress-playground-block-button button-destructive"
-												onClick={() => {
-													setActiveFileIndex(0);
-													removeFile(activeFileIndex);
-												}}
-											>
-												<Icon
-													icon={cancelCircleFilled}
-												/>{' '}
-												Remove file
-											</button>
-										)}
-									{isEditFileNameModalOpen && (
-										<FileNameModal
-											title="Edit file name"
-											initialFilename={
-												files[activeFileIndex].name
-											}
-											onRequestClose={() =>
-												setEditFileNameModalOpen(false)
-											}
-											onSave={(fileName) => {
-												updateFile((file) => ({
-													...file,
-													name: fileName,
-												}));
-												setEditFileNameModalOpen(false);
-											}}
-										/>
-									)}
-								</div>
-							) : (
-								<div className="file-actions"></div>
-							)}
-							<Button
-								variant="primary"
-								icon="controls-play"
-								iconPosition="right"
-								onClick={() => {
-									handleReRunCode();
-								}}
-								className="wordpress-playground-run-button"
-							>
-								Run
-							</Button>
-						</div>
-					</div>
+				{!isActivated && (
+					<Button
+						className="wordpress-playground-activate-button"
+						onClick={() => setActivated(true)}
+					>Activate WordPress Playground</Button>
 				)}
-				<iframe
-					key="playground-iframe"
-					ref={iframeRef}
-					className="playground-iframe"
-				></iframe>
+				{isActivated && (
+					<>
+					    {codeEditor && (
+					    	<div className={codeContainerClass}>
+					    		<div className="file-tabs">
+					    			{files.map((file, index) => (
+					    				<Button
+					    					key={file.name}
+					    					variant="primary"
+					    					className={`file-tab ${
+					    						index === activeFileIndex &&
+					    						'file-tab-active'
+					    					}`}
+					    					onClick={() => {
+					    						setActiveFileIndex(index);
+					    					}}
+					    					onDoubleClick={() => {
+					    						setEditFileNameModalOpen(true);
+					    					}}
+					    				>
+					    					{file.name}
+					    				</Button>
+					    			))}
+					    			{showAddNewFile && (
+					    				<Button
+					    					variant="secondary"
+					    					className="file-tab file-tab-extra"
+					    					onClick={() => setNewFileModalOpen(true)}
+					    				>
+					    					<Icon icon={plus} />
+					    				</Button>
+					    			)}
+					    			<Button
+					    				variant="secondary"
+					    				className="file-tab file-tab-extra"
+					    				onClick={() => {
+					    					if (playgroundClientRef.current) {
+					    						downloadZippedPlugin(
+					    							playgroundClientRef.current
+					    						);
+					    					}
+					    				}}
+					    			>
+					    				<Icon icon={download} />
+					    			</Button>
+					    			{isNewFileModalOpen && (
+					    				<FileNameModal
+					    					title="Create new file"
+					    					onRequestClose={() =>
+					    						setNewFileModalOpen(false)
+					    					}
+					    					onSave={(newFileName) => {
+					    						addFile({
+					    							name: newFileName,
+					    							contents: '',
+					    						});
+					    						setActiveFileIndex(files.length);
+					    						setNewFileModalOpen(false);
+					    					}}
+					    				/>
+					    			)}
+					    		</div>
+					    		<div className="code-editor-wrapper">
+					    			<ReactCodeMirror
+					    				value={activeFile.contents}
+					    				extensions={[
+					    					keymapExtension,
+					    					EditorView.lineWrapping,
+					    					...getLanguageExtensions(
+					    						currentFileExtension || 'js'
+					    					),
+					    				]}
+					    				readOnly={codeEditorReadOnly}
+					    				onChange={(value) =>
+					    					updateFile((file) => ({
+					    						...file,
+					    						contents: value,
+					    					}))
+					    				}
+					    			/>
+					    		</div>
+					    		<div className="actions-bar">
+					    			{showFileControls ? (
+					    				<div className="file-actions">
+					    					{!activeFile && (
+					    						<button
+					    							type="button"
+					    							onClick={() => {
+					    								setEditFileNameModalOpen(true);
+					    							}}
+					    							className="wordpress-playground-block-button button-non-destructive"
+					    						>
+					    							<Icon icon={edit} /> Edit file name
+					    						</button>
+					    					)}
+					    					{!isErrorLogFile(activeFile) &&
+					    						files.filter(
+					    							(file) => !isErrorLogFile(file)
+					    						).length > 1 && (
+					    							<button
+					    								type="button"
+					    								className="wordpress-playground-block-button button-destructive"
+					    								onClick={() => {
+					    									setActiveFileIndex(0);
+					    									removeFile(activeFileIndex);
+					    								}}
+					    							>
+					    								<Icon
+					    									icon={cancelCircleFilled}
+					    								/>{' '}
+					    								Remove file
+					    							</button>
+					    						)}
+					    					{isEditFileNameModalOpen && (
+					    						<FileNameModal
+					    							title="Edit file name"
+					    							initialFilename={
+					    								files[activeFileIndex].name
+					    							}
+					    							onRequestClose={() =>
+					    								setEditFileNameModalOpen(false)
+					    							}
+					    							onSave={(fileName) => {
+					    								updateFile((file) => ({
+					    									...file,
+					    									name: fileName,
+					    								}));
+					    								setEditFileNameModalOpen(false);
+					    							}}
+					    						/>
+					    					)}
+					    				</div>
+					    			) : (
+					    				<div className="file-actions"></div>
+					    			)}
+					    			<Button
+					    				variant="primary"
+					    				icon="controls-play"
+					    				iconPosition="right"
+					    				onClick={() => {
+					    					handleReRunCode();
+					    				}}
+					    				className="wordpress-playground-run-button"
+					    			>
+					    				Run
+					    			</Button>
+					    		</div>
+					    	</div>
+					    )}
+					    <iframe
+					    	key="playground-iframe"
+					    	ref={iframeRef}
+					    	className="playground-iframe"
+					    ></iframe>
+					</>
+				)}
 			</main>
 			<footer className="demo-footer">
 				<a

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -89,6 +89,7 @@ export default function PlaygroundPreview({
 	showAddNewFile = false,
 	showFileControls = false,
 	codeEditorErrorLog = false,
+	requireLivePreviewActivation = true,
 	onStateChange,
 }: PlaygroundDemoProps) {
 	const {
@@ -110,7 +111,8 @@ export default function PlaygroundPreview({
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 	const playgroundClientRef = useRef<PlaygroundClient | null>(null);
 
-	const [isActivated, setActivated] = useState(false);
+	const [isLivePreviewActivated, setLivePreviewActivated] =
+		useState(!requireLivePreviewActivation);
 	const [currentPostId, setCurrentPostId] = useState(0);
 	const [isNewFileModalOpen, setNewFileModalOpen] = useState(false);
 	const [isEditFileNameModalOpen, setEditFileNameModalOpen] = useState(false);
@@ -130,7 +132,7 @@ export default function PlaygroundPreview({
 
 	useEffect(() => {
 		async function initPlayground() {
-			if (!isActivated) {
+			if (!isLivePreviewActivated) {
 				return;
 			}
 			if (!iframeRef.current) {
@@ -223,7 +225,7 @@ export default function PlaygroundPreview({
 
 		initPlayground();
 	}, [
-		isActivated,
+		isLivePreviewActivated,
 		blueprint,
 		blueprintUrl,
 		configurationSource,
@@ -448,17 +450,17 @@ export default function PlaygroundPreview({
 						</div>
 					</div>
 				)}
-				{!isActivated && (
+				{!isLivePreviewActivated && (
 					<div className="playground-activation-placeholder">
 						<Button
 							className="wordpress-playground-activate-button"
-							onClick={() => setActivated(true)}
+							onClick={() => setLivePreviewActivated(true)}
 						>
 							Activate Live Preview
 						</Button>
 					</div>
 				)}
-				{isActivated && (
+				{isLivePreviewActivated && (
 					<iframe
 						key="playground-iframe"
 						ref={iframeRef}

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -456,6 +456,11 @@ export default function PlaygroundPreview({
 						<Button
 							className="wordpress-playground-activate-button"
 							onClick={() => setLivePreviewActivated(true)}
+							aria-description={
+								'This button creates an iframe containing ' +
+								'a full WordPress website which may be ' +
+								'a challenge for screen readers.'
+							}
 						>
 							Activate Live Preview
 						</Button>

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -455,6 +455,7 @@ export default function PlaygroundPreview({
 					<div className="playground-activation-placeholder">
 						<Button
 							className="wordpress-playground-activate-button"
+							variant="primary"
 							onClick={() => setLivePreviewActivated(true)}
 							aria-description={
 								'This button creates an iframe containing ' +

--- a/packages/wordpress-playground-block/src/edit.tsx
+++ b/packages/wordpress-playground-block/src/edit.tsx
@@ -133,7 +133,7 @@ export default function Edit({
 									onChange={() => {
 										setAttributes({
 											requireLivePreviewActivation:
-												!requireLivePreviewActivation
+												!requireLivePreviewActivation,
 										});
 									}}
 								/>

--- a/packages/wordpress-playground-block/src/edit.tsx
+++ b/packages/wordpress-playground-block/src/edit.tsx
@@ -42,6 +42,7 @@ export default function Edit({
 		codeEditorErrorLog,
 		blueprintUrl,
 		configurationSource,
+		requireLivePreviewActivation,
 	} = attributes;
 
 	return (
@@ -117,6 +118,22 @@ export default function Edit({
 										setAttributes({
 											codeEditorMultipleFiles:
 												!codeEditorMultipleFiles,
+										});
+									}}
+								/>
+								<ToggleControl
+									label="Require live preview activation"
+									help={
+										// TODO: Fix line lengths
+										requireLivePreviewActivation
+											? 'Load live preview after activation.'
+											: 'Load live preview immediately.'
+									}
+									checked={requireLivePreviewActivation}
+									onChange={() => {
+										setAttributes({
+											requireLivePreviewActivation:
+												!requireLivePreviewActivation
 										});
 									}}
 								/>

--- a/packages/wordpress-playground-block/src/edit.tsx
+++ b/packages/wordpress-playground-block/src/edit.tsx
@@ -124,10 +124,9 @@ export default function Edit({
 								<ToggleControl
 									label="Require live preview activation"
 									help={
-										// TODO: Fix line lengths
 										requireLivePreviewActivation
-											? 'Load live preview after activation.'
-											: 'Load live preview immediately.'
+											? 'User must click to load the preview.'
+											: 'Preview begins loading immediately.'
 									}
 									checked={requireLivePreviewActivation}
 									onChange={() => {

--- a/packages/wordpress-playground-block/src/index.ts
+++ b/packages/wordpress-playground-block/src/index.ts
@@ -37,6 +37,7 @@ export type Attributes = {
 		| 'block-attributes'
 		| 'blueprint-url'
 		| 'blueprint-json';
+	requireLivePreviewActivation: boolean;
 };
 
 // Load the edit component asynchronously. This may take a while,

--- a/packages/wordpress-playground-block/src/style.scss
+++ b/packages/wordpress-playground-block/src/style.scss
@@ -1,4 +1,6 @@
 .wp-block-wordpress-playground-playground {
+	$container-height: 700px;
+
 	border-radius: 10px;
 
 	* {
@@ -25,11 +27,17 @@
 		cursor: pointer;
 	}
 
+	.wordpress-playground-activate-button {
+		margin: auto;
+		font-size: 20px;
+	}
+
 	.demo-container {
 		display: flex;
 		flex-wrap: wrap;
 		box-shadow: #03254b47 0px 12px 50px 0px;
 		overflow: hidden;
+		height: $container-height;
 	}
 
 	.demo-footer {
@@ -150,10 +158,11 @@
 
 	.playground-iframe {
 		flex: 1;
-		width: 700px;
-		max-width: 100%;
-		height: 700px;
+		height: $container-height;
 		max-height: 100%;
+		// Set width to height so the iframe is square
+		width: $container-height;
+		max-width: 100%;
 		border: 0;
 	}
 

--- a/packages/wordpress-playground-block/src/style.scss
+++ b/packages/wordpress-playground-block/src/style.scss
@@ -167,6 +167,7 @@
 	.playground-activation-placeholder {
 		@include playground-pane;
 		display: flex;
+		background-color: #eee;
 	}
 
 	.wordpress-playground-activate-button {

--- a/packages/wordpress-playground-block/src/style.scss
+++ b/packages/wordpress-playground-block/src/style.scss
@@ -1,5 +1,5 @@
 .wp-block-wordpress-playground-playground {
-	$container-height: 700px;
+	$playground-height: 700px;
 
 	border-radius: 10px;
 
@@ -27,17 +27,11 @@
 		cursor: pointer;
 	}
 
-	.wordpress-playground-activate-button {
-		margin: auto;
-		font-size: 20px;
-	}
-
 	.demo-container {
 		display: flex;
 		flex-wrap: wrap;
 		box-shadow: #03254b47 0px 12px 50px 0px;
 		overflow: hidden;
-		height: $container-height;
 	}
 
 	.demo-footer {
@@ -156,14 +150,28 @@
 		white-space: pre-wrap;
 	}
 
-	.playground-iframe {
+	@mixin playground-pane {
 		flex: 1;
-		height: $container-height;
+		height: $playground-height;
 		max-height: 100%;
 		// Set width to height so the iframe is square
-		width: $container-height;
+		width: $playground-height;
 		max-width: 100%;
 		border: 0;
+	}
+
+	.playground-iframe {
+		@include playground-pane;
+	}
+
+	.playground-activation-placeholder {
+		@include playground-pane;
+		display: flex;
+	}
+
+	.wordpress-playground-activate-button {
+		margin: auto;
+		font-size: 20px;
 	}
 
 	.actions-bar {


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->
This PR updates the wordpress-playground-block to only load Playground after an Activate button has been clicked.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
IFrames can create difficulty for those using Screen Readers. See: [#](https://github.com/WordPress/Learn/pull/2264#issuecomment-1971503159), [#](https://github.com/WordPress/Learn/pull/2264#issuecomment-1979277253)

Requiring user action to load Playground will help avoid distracting screen readers with auto-loading iframes. As a bonus, it would also stop the block from automatically consuming network bandwidth to download Playground assets, even if Playground will not be used.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This button must be clicked before the code editor and Playground load, so the iframe no longer loads immediately.

## Questions

Would it be better to just gate the iframe with an Activate button? Perhaps that doesn't make sense because of the expected interaction with the code editor, but I think it _might_ look better than a single activation button in the middle of a large block like this one.

