### PR TITLE
Vscode extension: update WordPress versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48374,7 +48374,7 @@
 		},
 		"packages/vscode-extension": {
 			"name": "wordpress-playground",
-			"version": "0.1.56",
+			"version": "0.1.57",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"vscode": "^1.77.0"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"predeploy": "nx build docs-site",
 		"prepublishOnly": "npm run build",
 		"release:wp-now": "lerna version patch --yes --no-private --loglevel=verbose && cd dist/packages/wp-now && npm publish --access public",
+		"release:vscode": "nx publish vscode-extension",
 		"test": "nx run-many --all --target=test",
 		"fix-asyncify": "node packages/php-wasm/node/bin/rebuild-while-asyncify-functions-missing.mjs",
 		"typecheck": "nx run-many --all --target=typecheck",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -4,7 +4,7 @@
 	"description": "Embeds a WordPress installation in your your VS Code",
 	"license": "GPL-2.0-or-later",
 	"publisher": "WordPressPlayground",
-	"version": "0.1.56",
+	"version": "0.1.57",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/WordPress/playground-tools"

--- a/packages/vscode-extension/src/webview.tsx
+++ b/packages/vscode-extension/src/webview.tsx
@@ -12,10 +12,9 @@ import {
 // @TODO Move to @wp-playground/wordpress package
 const SupportedWordPressVersions = {
 	latest: 'Latest (auto-updated)',
+	'6.4': '6.4',
+	'6.3': '6.3',
 	'6.2': '6.2',
-	'6.1': '6.1',
-	'6.0': '6.0',
-	'5.9': '5.9',
 } as Record<string, string>;
 
 // @ts-ignore


### PR DESCRIPTION
## What?

Updates the WordPress versions displayed in the UI. The latest available version is now 6.4.

## Testing instructions

Install the extensions using the instructions from its README and confirm the latest available WP version is now 6.4.

## Follow-up work

Retrieve the available versions from the public API endpoint when a network connection is available. Otherwise, make a note about the network connection being down and display the versions present in a local cache.

