### PR TITLE
VS Code and wp-now: Allow the login() step to fail

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,8 @@
             "request": "launch",
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}/dist/packages/vscode-extension"
-            ]
+            ],
+            "preLaunchTask": "build-vscode-extension"
         },
         {
           "name": "Heap Profiler",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,8 +10,7 @@
             "request": "launch",
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}/dist/packages/vscode-extension"
-            ],
-            "preLaunchTask": "build-vscode-extension"
+            ]
         },
         {
           "name": "Heap Profiler",

--- a/package-lock.json
+++ b/package-lock.json
@@ -48374,7 +48374,7 @@
 		},
 		"packages/vscode-extension": {
 			"name": "wordpress-playground",
-			"version": "0.1.57",
+			"version": "0.1.60",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"vscode": "^1.77.0"

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -4,7 +4,7 @@
 	"description": "Embeds a WordPress installation in your your VS Code",
 	"license": "GPL-2.0-or-later",
 	"publisher": "WordPressPlayground",
-	"version": "0.1.57",
+	"version": "0.1.60",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/WordPress/playground-tools"

--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -127,10 +127,16 @@ export default async function startWPNow(
 	}
 
 	await installationStep2(php);
-	await login(php, {
-		username: 'admin',
-		password: 'password',
-	});
+	try {
+		await login(php, {
+			username: 'admin',
+			password: 'password',
+		});
+	} catch (e) {
+		// It's okay if the user customized the username and password
+		// and the login fails now.
+		output?.error('Login failed');
+	}
 
 	if (
 		isFirstTimeProject &&


### PR DESCRIPTION
The user may customize their login details. Changing the password should not prevent them from starting the server again. This PR adds tolerance for login() failures.

## Other changes

This PR also bumps the VS Code extension version

## Testing instructions

1. Start a wp-now site
1. Change the admin password
1. Restart the site
1. Confirm the server started
1. Confirm it wouldn't start on trunk
