### PR TITLE
WP-NOW: Add GitHub action to release a new version

### DIFF
--- a/.github/workflows/release-wp-now.yml
+++ b/.github/workflows/release-wp-now.yml
@@ -2,16 +2,6 @@ name: Release wp-now
 
 on:
     workflow_dispatch:
-        # Require a version bump (patch, minor, major) and an optional dist tag
-        inputs:
-            version_bump:
-                description: 'Version bump (patch, minor, or major)'
-                required: true
-                default: 'patch'
-            dist_tag:
-                description: 'Dist tag (latest, next, etc.)'
-                required: false
-                default: 'latest'
 
 jobs:
     release:

--- a/.github/workflows/release-wp-now.yml
+++ b/.github/workflows/release-wp-now.yml
@@ -1,0 +1,60 @@
+name: Release wp-now
+
+on:
+    workflow_dispatch:
+        # Require a version bump (patch, minor, major) and an optional dist tag
+        inputs:
+            version_bump:
+                description: 'Version bump (patch, minor, or major)'
+                required: true
+                default: 'patch'
+            dist_tag:
+                description: 'Dist tag (latest, next, etc.)'
+                required: false
+                default: 'latest'
+
+jobs:
+    release:
+        # Only run this workflow from the trunk branch and when it's triggered by dmsnell OR adamziel
+        if: >
+            github.ref == 'refs/heads/trunk' && (
+                github.actor == 'adamziel' ||
+                github.actor == 'dmsnell' ||
+                github.actor == 'bgrgicak' ||
+                github.actor == 'sejas' ||
+                github.actor == 'danielbachchuber'
+            )
+
+        # Specify runner + deployment step
+        runs-on: ubuntu-latest
+        environment:
+            name: npm
+        env:
+            NPM_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  ref: ${{ github.event.pull_request.head.ref }}
+                  clean: true
+                  fetch-depth: 0
+                  persist-credentials: false
+            - name: Setup SSH Keys
+              uses: webfactory/ssh-agent@v0.5.3
+              with:
+                  ssh-private-key: ${{ secrets.GH_DEPLOY_KEY }}
+            - name: Config git user
+              run: |
+                  git config --global user.name "deployment_bot"
+                  git config --global user.email "deployment_bot@users.noreply.github.com"
+            - name: Authenticate with Registry
+              run: |
+                  echo "@wp-now:registry=https://registry.npmjs.org/" >> ~/.npmrc
+                  echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
+                  echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+            - uses: ./.github/actions/prepare-playground
+            # Version bump, release, tag a new version on GitHub
+            - name: Release new version of NPM packages
+              shell: bash
+              run: |
+                  npm run build
+                  npm run release:wp-now

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "node_modules/lerna/schemas/lerna-schema.json",
 	"useWorkspaces": true,
-	"version": "0.1.65",
+	"version": "0.1.66",
 	"useNx": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -48382,7 +48382,7 @@
 		},
 		"packages/wp-now": {
 			"name": "@wp-now/wp-now",
-			"version": "0.1.65",
+			"version": "0.1.66",
 			"license": "GPL-2.0-or-later",
 			"bin": {
 				"wp-now": "with-node-version.js"

--- a/packages/wp-now/package.json
+++ b/packages/wp-now/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wp-now/wp-now",
-	"version": "0.1.65",
+	"version": "0.1.66",
 	"description": "WordPress Playground CLI",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## What?

Let's make wp-now releases easy with a GitHub workflow.

## Testing instructions

This workflow cannot be tested without merging and running it. Read this PR, confirm it makes sense, and then let's merge and iterate on the workflow.

cc @sejas @bgrgicak 