### PR TITLE
Fix side-by-side code editor to be full height within container

### DIFF
--- a/packages/wordpress-playground-block/src/style.scss
+++ b/packages/wordpress-playground-block/src/style.scss
@@ -141,7 +141,7 @@
 	.cm-editor {
 		width: 100%;
 		height: 100%;
-		max-height: min(450px, 80vh);
+		max-height: 100%;
 	}
 
 	.cm-content {

--- a/packages/wordpress-playground-block/src/style.scss
+++ b/packages/wordpress-playground-block/src/style.scss
@@ -135,13 +135,26 @@
 
 		> div {
 			height: 100%;
+			// Make this a "positioned" element so a nested editor element
+			// may be absolutely positioned relative to this one.
+			position: relative;
 		}
 	}
 
-	.cm-editor {
+	.is-full-width .cm-editor {
 		width: 100%;
 		height: 100%;
-		max-height: 100%;
+		max-height: min(450px, 80vh);
+	}
+
+	.is-half-width .cm-editor {
+		// Override the editor's `position: relative !important` style in order
+		// to explicitly set dimensions relative to the positioned editor root.
+		position: absolute !important;
+		top: 0;
+		left: 0;
+		bottom: 0;
+		right: 0;
 	}
 
 	.cm-content {


### PR DESCRIPTION
## What?

This PR fixes an issue with code editor height. Before this PR, there were some cases where the code editor left some bottom space between it and the Run bar blank and unoccupied.

Before:
![before-height-fix](https://github.com/WordPress/playground-tools/assets/530877/52577f2a-8f47-439a-919e-852fb6c0497c)

After:
![after-height-fix](https://github.com/WordPress/playground-tools/assets/530877/8674fc71-c5bb-4925-a9b9-555a84153384)

## Why?

It can be aesthetically displeasing and sometimes confusing to have open, purposeless space within the block.

## How?

This PR changes max-height from
`min(450px, 80vh)`
to
`100%`.

It is possible this is the wrong solution, but I do not currently see a reason we wouldn't want the editor pane to take 100% of the available size.

## Testing Instructions

Check out this branch, follow the [Contributing instructions](https://github.com/WordPress/playground-tools/tree/trunk/packages/wordpress-playground-block#contributing) to build and start a dev version of WordPress, create a post containing the block, and observe the block rendering in the editor and on the front end.

