### PR TITLE
playground block: Add initial i18n support

### DIFF
--- a/packages/wordpress-playground-block/src/block.json
+++ b/packages/wordpress-playground-block/src/block.json
@@ -121,6 +121,12 @@
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css",
 	"style": ["file:./style-index.css", "wp-components"],
-	"viewScript": ["file:./view.js", "react", "react-dom", "wp-components"],
+	"viewScript": [
+		"file:./view.js",
+		"react",
+		"react-dom",
+		"wp-components",
+		"wp-i18n"
+	],
 	"render": "file:./render.php"
 }

--- a/packages/wordpress-playground-block/src/components/file-name-modal.tsx
+++ b/packages/wordpress-playground-block/src/components/file-name-modal.tsx
@@ -5,6 +5,7 @@ import {
 	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 interface FileNameModalProps {
 	title: string;
@@ -39,7 +40,7 @@ export function FileNameModal({
 				/>
 				<br />
 				<Button variant="primary" type="submit">
-					Done
+					{__('Done', 'interactive-code-block')}
 				</Button>
 			</form>
 		</Modal>

--- a/packages/wordpress-playground-block/src/components/playground-preview/download-zipped-plugin.ts
+++ b/packages/wordpress-playground-block/src/components/playground-preview/download-zipped-plugin.ts
@@ -3,6 +3,7 @@ import {
 	phpVar,
 	// @ts-ignore
 } from 'https://playground.wordpress.net/client/index.js';
+import { __ } from '@wordpress/i18n';
 
 export default async function downloadZippedPlugin(client: PlaygroundClient) {
 	const docroot = await client.documentRoot;
@@ -50,7 +51,7 @@ async function zipPlaygroundFiles(client: PlaygroundClient, path: string) {
 			`,
 	});
 	if (result.text !== 'done') {
-		console.log('Error creating zip file');
+		console.log(__('Error creating zip file', 'interactive-code-block'));
 		console.log(result.errors);
 		console.log(result.text);
 	}

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -29,6 +29,7 @@ import { LanguageSupport } from '@codemirror/language';
 import { writePluginFiles } from './write-plugin-files';
 import downloadZippedPlugin from './download-zipped-plugin';
 import classnames from 'classnames';
+import { __ } from '@wordpress/i18n';
 
 export type PlaygroundDemoProps = Attributes & {
 	showAddNewFile: boolean;
@@ -80,7 +81,7 @@ export default function PlaygroundPreview({
 	logInUser,
 	createNewPost,
 	createNewPostType = 'post',
-	createNewPostTitle = 'New post',
+	createNewPostTitle = __('New post', 'interactive-code-block'),
 	createNewPostContent = '',
 	redirectToPost,
 	redirectToPostType = 'front',
@@ -187,7 +188,9 @@ export default function PlaygroundPreview({
 			if (finalBlueprint) {
 				configuration['blueprint'] = finalBlueprint;
 			}
-			console.log('Initializing Playground');
+			console.log(
+				__('Initializing Playground', 'interactive-code-block')
+			);
 			const client = await startPlaygroundWeb(configuration);
 
 			await client.isReady();
@@ -307,9 +310,11 @@ export default function PlaygroundPreview({
 		'is-half-width': codeEditorSideBySide,
 	});
 
-	const iframeCreationWarning =
+	const iframeCreationWarning = __(
 		'This button creates an iframe containing a full WordPress website ' +
-		'which may be a challenge for screen readers.';
+			'which may be a challenge for screen readers.',
+		'interactive-code-block'
+	);
 
 	return (
 		<>
@@ -359,7 +364,10 @@ export default function PlaygroundPreview({
 							</Button>
 							{isNewFileModalOpen && (
 								<FileNameModal
-									title="Create new file"
+									title={__(
+										'Create new file',
+										'interactive-code-block'
+									)}
 									onRequestClose={() =>
 										setNewFileModalOpen(false)
 									}
@@ -404,7 +412,11 @@ export default function PlaygroundPreview({
 											}}
 											className="wordpress-playground-block-button button-non-destructive"
 										>
-											<Icon icon={edit} /> Edit file name
+											<Icon icon={edit} />{' '}
+											{__(
+												'Edit file name',
+												'interactive-code-block'
+											)}
 										</button>
 									)}
 									{!isErrorLogFile(activeFile) &&
@@ -422,12 +434,18 @@ export default function PlaygroundPreview({
 												<Icon
 													icon={cancelCircleFilled}
 												/>{' '}
-												Remove file
+												{__(
+													'Remove file',
+													'interactive-code-block'
+												)}
 											</button>
 										)}
 									{isEditFileNameModalOpen && (
 										<FileNameModal
-											title="Edit file name"
+											title={__(
+												'Edit file name',
+												'interactive-code-block'
+											)}
 											initialFilename={
 												files[activeFileIndex].name
 											}
@@ -461,7 +479,7 @@ export default function PlaygroundPreview({
 										: undefined
 								}
 							>
-								Run
+								{__('Run', 'interactive-code-block')}
 							</Button>
 						</div>
 					</div>
@@ -474,13 +492,19 @@ export default function PlaygroundPreview({
 							onClick={() => setLivePreviewActivated(true)}
 							aria-description={iframeCreationWarning}
 						>
-							Activate Live Preview
+							{__(
+								'Activate Live Preview',
+								'interactive-code-block'
+							)}
 						</Button>
 					</div>
 				)}
 				{isLivePreviewActivated && (
 					<iframe
-						aria-label="Live Preview in WordPress Playground"
+						aria-label={__(
+							'Live Preview in WordPress Playground',
+							'interactive-code-block'
+						)}
 						key="playground-iframe"
 						ref={iframeRef}
 						className="playground-iframe"
@@ -493,10 +517,12 @@ export default function PlaygroundPreview({
 					className="demo-footer__link"
 					target="_blank"
 				>
-					<span className="demo-footer__powered">Powered by</span>
+					<span className="demo-footer__powered">
+						{__('Powered by', 'interactive-code-block')}
+					</span>
 					<Icon className="demo-footer__icon" icon={wordpress} />
 					<span className="demo-footer__link-text">
-						WordPress Playground
+						{__('WordPress Playground', 'interactive-code-block')}
 					</span>
 				</a>
 			</footer>

--- a/packages/wordpress-playground-block/src/edit.tsx
+++ b/packages/wordpress-playground-block/src/edit.tsx
@@ -16,6 +16,7 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import PlaygroundPreview from './components/playground-preview';
+import { __ } from '@wordpress/i18n';
 import './editor.scss';
 
 export default function Edit({
@@ -58,14 +59,17 @@ export default function Edit({
 				{...attributes}
 			/>
 			<InspectorControls>
-				<Panel header="Settings">
-					<PanelBody title="Code editor" initialOpen={true}>
+				<Panel header={__('Settings', 'interactive-code-editor')}>
+					<PanelBody
+						title={__('Code editor', 'interactive-code-editor')}
+						initialOpen={true}
+					>
 						<ToggleControl
-							label="Code editor"
+							label={__('Code editor', 'interactive-code-editor')}
 							help={
 								codeEditor
-									? 'Code editor enabled.'
-									: 'Code editor disabled.'
+									? __('Code editor enabled.', 'interactive-code-editor')
+									: __('Code editor disabled.', 'interactive-code-editor')
 							}
 							checked={codeEditor}
 							onChange={() => {
@@ -77,11 +81,14 @@ export default function Edit({
 						{codeEditor && (
 							<>
 								<ToggleControl
-									label="Side by side"
+									label={__(
+										'Side by side',
+										'interactive-code-editor'
+									)}
 									help={
 										codeEditorSideBySide
-											? 'Code editor is to the left.'
-											: 'Code editor is at the top.'
+											? __('Code editor is to the left.', 'interactive-code-editor')
+											: __('Code editor is at the top.', 'interactive-code-editor')
 									}
 									checked={codeEditorSideBySide}
 									onChange={() => {
@@ -92,11 +99,14 @@ export default function Edit({
 									}}
 								/>
 								<ToggleControl
-									label="Read only"
+									label={__(
+										'Read only',
+										'interactive-code-editor'
+									)}
 									help={
 										codeEditorReadOnly
-											? 'Code editor is read only.'
-											: 'Code editor is editable.'
+											? __('Code editor is read only.', 'interactive-code-block')
+											: __('Code editor is editable.', 'interactive-code-block')
 									}
 									checked={codeEditorReadOnly}
 									onChange={() => {
@@ -107,11 +117,14 @@ export default function Edit({
 									}}
 								/>
 								<ToggleControl
-									label="Multiple files"
+									label={__(
+										'Multiple files',
+										'interactive-code-block'
+									)}
 									help={
 										codeEditorMultipleFiles
-											? 'Multiple files allowed.'
-											: 'Single file allowed.'
+											? __('Multiple files allowed.', 'interactive-code-block')
+											: __('Single file allowed.', 'interactive-code-block')
 									}
 									checked={codeEditorMultipleFiles}
 									onChange={() => {
@@ -122,11 +135,14 @@ export default function Edit({
 									}}
 								/>
 								<ToggleControl
-									label="Require live preview activation"
+									label={__(
+										'Require live preview activation',
+										'interactive-code-block'
+									)}
 									help={
 										requireLivePreviewActivation
-											? 'User must click to load the preview.'
-											: 'Preview begins loading immediately.'
+											? __('User must click to load the preview.', 'interactive-code-block')
+											: __('Preview begins loading immediately.', 'interactive-code-block')
 									}
 									checked={requireLivePreviewActivation}
 									onChange={() => {
@@ -137,7 +153,10 @@ export default function Edit({
 									}}
 								/>
 								<ToggleControl
-									label='Include "error_log" file'
+									label={__(
+										'Include "error_log" file',
+										'interactive-code-block'
+									)}
 									checked={codeEditorErrorLog}
 									onChange={() => {
 										setAttributes({
@@ -195,19 +214,31 @@ export default function Edit({
 												</ul>
 											</div>
 										}
-										label="Mode"
+										label={__(
+											'Mode',
+											'interactive-code-block'
+										)}
 										options={[
 											{
 												disabled: true,
-												label: 'Select an Option',
+												label: __(
+													'Select an Option',
+													'interactive-code-block'
+												),
 												value: '',
 											},
 											{
-												label: 'Editor script',
+												label: __(
+													'Editor script',
+													'interactive-code-block'
+												),
 												value: 'editor-script',
 											},
 											{
-												label: 'Plugin',
+												label: __(
+													'Plugin',
+													'interactive-code-block'
+												),
 												value: 'plugin',
 											},
 										]}
@@ -222,21 +253,33 @@ export default function Edit({
 							</>
 						)}
 					</PanelBody>
-					<PanelBody title="Blueprint" initialOpen={false}>
+					<PanelBody
+						title={__('Blueprint', 'interactive-code-block')}
+						initialOpen={false}
+					>
 						<SelectControl
-							label="Blueprint source"
+							label={__(
+								'Blueprint source',
+								'interactive-code-block'
+							)}
 							value={configurationSource}
 							options={[
 								{
-									label: 'Generate from block attributes',
+									label: __(
+										'Generate from block attributes',
+										'interactive-code-block'
+									),
 									value: 'block-attributes',
 								},
 								{
-									label: 'URL',
+									label: __('URL', 'interactive-code-block'),
 									value: 'blueprint-url',
 								},
 								{
-									label: 'JSON (paste it below)',
+									label: __(
+										'JSON (paste it below)',
+										'interactive-code-block'
+									),
 									value: 'blueprint-json',
 								},
 							]}
@@ -245,10 +288,11 @@ export default function Edit({
 									configurationSource: newConfigurationSource,
 								});
 							}}
-							help={
+							help={__(
 								'Playground is configured using Blueprints. Select the source ' +
-								"of the Blueprint you'd like to use for this Playground instance."
-							}
+									"of the Blueprint you'd like to use for this Playground instance.",
+								'interactive-code-block'
+							)}
 						/>
 						{configurationSource === 'block-attributes' && (
 							<>
@@ -256,8 +300,8 @@ export default function Edit({
 									label="Log in automatically"
 									help={
 										logInUser
-											? 'User will be logged in.'
-											: "User won't be logged in."
+											? __('User will be logged in.', 'interactive-code-block')
+											: __("User won't be logged in.", 'interactive-code-block')
 									}
 									checked={logInUser}
 									onChange={() => {
@@ -267,11 +311,14 @@ export default function Edit({
 									}}
 								/>
 								<ToggleControl
-									label="Create new post or page"
+									label={__(
+										'Create new post or page',
+										'interactive-code-block'
+									)}
 									help={
 										createNewPost
-											? 'New post or page will be created.'
-											: 'No new posts or pages will be created.'
+											? __('New post or page will be created.', 'interactive-code-block')
+											: __('No new posts or pages will be created.', 'interactive-code-block')
 									}
 									checked={createNewPost}
 									onChange={() => {
@@ -283,7 +330,10 @@ export default function Edit({
 								{createNewPost && (
 									<>
 										<ToggleGroupControl
-											label="Create new: post type"
+											label={__(
+												'Create new: post type',
+												'interactive-code-block'
+											)}
 											value={createNewPostType}
 											onChange={(value: any) => {
 												setAttributes({
@@ -295,11 +345,17 @@ export default function Edit({
 										>
 											<ToggleGroupControlOption
 												value="post"
-												label="Post"
+												label={__(
+													'Post',
+													'interactive-code-block'
+												)}
 											/>
 											<ToggleGroupControlOption
 												value="page"
-												label="Page"
+												label={__(
+													'Page',
+													'interactive-code-block'
+												)}
 											/>
 										</ToggleGroupControl>
 										<InputControl
@@ -309,8 +365,14 @@ export default function Edit({
 													createNewPostTitle: value,
 												});
 											}}
-											label="Create new: title"
-											placeholder="Hello World!"
+											label={__(
+												'Create new: title',
+												'interactive-code-block'
+											)}
+											placeholder={__(
+												'Hello World!',
+												'interactive-code-block'
+											)}
 										/>
 										<TextareaControl
 											value={createNewPostContent}
@@ -319,15 +381,24 @@ export default function Edit({
 													createNewPostContent: value,
 												});
 											}}
-											label="Create new: content"
-											help="Gutenberg editor content of the post"
+											label={__(
+												'Create new: content',
+												'interactive-code-block'
+											)}
+											help={__(
+												'Gutenberg editor content of the post',
+												'interactive-code-block'
+											)}
 										/>
 										<ToggleControl
-											label="Create new: redirect to post"
+											label={__(
+												'Create new: redirect to post',
+												'interactive-code-block'
+											)}
 											help={
 												redirectToPost
-													? 'User will be redirected.'
-													: "User won't be redirected."
+													? __('User will be redirected.', 'interactive-code-block')
+													: __("User won't be redirected.", 'interactive-code-block')
 											}
 											checked={redirectToPost}
 											onChange={() => {
@@ -339,7 +410,10 @@ export default function Edit({
 										/>
 										{redirectToPost && (
 											<ToggleGroupControl
-												label="Create new redirect: redirect to"
+												label={__(
+													'Create new redirect: redirect to',
+													'interactive-code-block'
+												)}
 												value={redirectToPostType}
 												onChange={(value: any) => {
 													setAttributes({
@@ -351,11 +425,17 @@ export default function Edit({
 											>
 												<ToggleGroupControlOption
 													value="front"
-													label="Front page"
+													label={__(
+														'Front page',
+														'interactive-code-block'
+													)}
 												/>
 												<ToggleGroupControlOption
 													value="admin"
-													label="Edit screen"
+													label={__(
+														'Edit screen',
+														'interactive-code-block'
+													)}
 												/>
 											</ToggleGroupControl>
 										)}
@@ -369,9 +449,18 @@ export default function Edit({
 												landingPageUrl: value,
 											});
 										}}
-										label="Landing page"
-										help="Define where to redirect after Playground is loaded."
-										placeholder="URL to redirect to after load (eg. /wp-admin/)"
+										label={__(
+											'Landing page',
+											'interactive-code-block'
+										)}
+										help={__(
+											'Define where to redirect after Playground is loaded.',
+											'interactive-code-block'
+										)}
+										placeholder={__(
+											'URL to redirect to after load (eg. /wp-admin/)',
+											'interactive-code-block'
+										)}
 									/>
 								)}
 								{['WP_DEBUG', 'WP_SCRIPT_DEBUG'].map(
@@ -409,9 +498,18 @@ export default function Edit({
 										blueprintUrl: value,
 									});
 								}}
-								label="Blueprint URL"
-								help="Load Blueprint from this URL."
-								placeholder="URL to load the Blueprint from"
+								label={__(
+									'Blueprint URL',
+									'interactive-code-block'
+								)}
+								help={__(
+									'Load Blueprint from this URL.',
+									'interactive-code-block'
+								)}
+								placeholder={__(
+									'URL to load the Blueprint from',
+									'interactive-code-block'
+								)}
 							/>
 						)}
 						{configurationSource === 'blueprint-json' && (
@@ -422,8 +520,14 @@ export default function Edit({
 										blueprint: value,
 									});
 								}}
-								label="Blueprint"
-								help="JSON file with playground blueprint"
+								label={__(
+									'Blueprint',
+									'interactive-code-block'
+								)}
+								help={__(
+									'JSON file with playground blueprint',
+									'interactive-code-block'
+								)}
 							/>
 						)}
 					</PanelBody>

--- a/packages/wordpress-playground-block/src/index.ts
+++ b/packages/wordpress-playground-block/src/index.ts
@@ -5,6 +5,7 @@ import {
 	useEffect,
 	useState,
 } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 import metadata from './block.json';
 import './style.scss';
@@ -65,7 +66,10 @@ registerBlockType<Attributes>(metadata.name, {
 		}, []);
 		if (!isLoaded) {
 			return createElement('span', {}, [
-				'Loading the WordPress Playground Block...',
+				__(
+					'Loading the WordPress Playground Block...',
+					'interactive-code-block'
+				),
 			]);
 		}
 		return createElement(EditComponent as any, props);

--- a/packages/wordpress-playground-block/wordpress-playground-block.php
+++ b/packages/wordpress-playground-block/wordpress-playground-block.php
@@ -8,7 +8,7 @@
  * Author:            Dawid Urbański, Adam Zieliński
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
- * Text Domain:       wordpress-playground-block
+ * Text Domain:       interactive-code-block
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
## What?

This PR adds initial support for i18n.

I visually scanned PHP, TS, and TSX files and wrapped all the user-facing text I found with calls to `__()`. Because the Playground block is published under the slug `interactive-code-block`, that is the text domain used here.

There are a couple of tasks left:

- [ ] At least some of these need to be converted to `_x()` calls to add context for translators.
- [ ] There is a big block of HTML help text for "Mode" in `edit.tsx` that is not wrapped and needs more careful handling.

## Testing Instructions

1. Check out this branch
2. Run the dev environment with `nx run wordpress-playground-block:dev`
3. Start a new post with localhost:8881/wp-admin/post-new.php
4. Insert a WordPress playground block
5. Enable the Code Editor in the block's settings and poke around in other ways to make sure there are no obvious problems with user facing text.
