### PR TITLE
Playground plugin: autologin fix, \n escaping, remove parent admin bar

### DIFF
--- a/packages/playground/assets/css/playground.css
+++ b/packages/playground/assets/css/playground.css
@@ -14,6 +14,9 @@
 .tools_page_playground #wpbody {
 	position: initial;
 }
+.tools_page_playground #wpadminbar {
+	display: none;
+}
 
 #wp-playground-toolbar {
 	background-color: #eaaa00;

--- a/packages/playground/assets/js/playground.js
+++ b/packages/playground/assets/js/playground.js
@@ -27,7 +27,21 @@
 				},
 			},
 			{
-				step: 'login',
+				step: 'writeFile',
+				path: '/wordpress/wp-content/mu-plugins/0-login.php',
+				data: `<?php
+					add_action( 'setup_theme', function() {
+						if ( is_user_logged_in() ) {
+							return;
+						}
+						$user = get_user_by( 'id', ${playground.userId} );
+						if( $user ) {
+							wp_set_current_user( $user->ID, $user->user_login );
+							wp_set_auth_cookie( $user->ID );
+							do_action( 'wp_login', $user->user_login, $user );
+						}
+					} );
+				`,
 			},
 		],
 	};
@@ -52,10 +66,11 @@
 	});
 
 	await client.isReady();
+	await client.goTo('/');
 
-	if (playground.pluginSlug) {
-		client.goTo('/wp-admin/plugins.php');
-	} else {
-		client.goTo('/wp-admin');
-	}
+	// if (playground.pluginSlug) {
+	// 	await client.goTo('/wp-admin/plugins.php');
+	// } else {
+	// 	await client.goTo('/wp-admin/');
+	// }
 })();

--- a/packages/playground/playground.php
+++ b/packages/playground/playground.php
@@ -62,6 +62,7 @@ function enqueue_scripts($current_screen_id)
 		),
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		'pluginSlug' => isset($_GET['pluginSlug']) ? $_GET['pluginSlug'] : false,
+		'userId' => get_current_user_id(),
 	]);
 	wp_enqueue_script('playground');
 }

--- a/packages/playground/src/playground-db.php
+++ b/packages/playground/src/playground-db.php
@@ -18,7 +18,7 @@ function escape_array($array)
 		if (is_numeric($value)) {
 			$escaped[] = $wpdb->prepare('%d', $value);
 		} else {
-			$escaped[] = $wpdb->prepare('%s', str_replace("\n", "\\n", $value));
+			$escaped[] = $wpdb->prepare('%s', $value);
 		}
 	}
 	return implode(',', $escaped);


### PR DESCRIPTION
Fixes #193

<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

This PR fixes a few issues reported in #193.
- Allows users to login if they don't use `admin/password` as login credentials.
- Removes the parent admin bar from the sandbox page.
- Removes `\n` escaping from the DB exporter

## Why?

### Login

Users with custom usernames and passwords weren't automatically logged into Playground because the credentials didn't match.

### Admin bar

We don't want the parent admin bar to be visible as it would be confusing. 

### \n

Initially, we decided to escape \n as a precaution, but it broke new lines in post content and started displaying them as characters on the page. Escaping isn't necessary and it breaks the export so we can remove it.

## How?

### Login

By adding a mu-plugin using blueprints to programmatically login the current user using their id.

### Admin bar

By hiding it with CSS on the Playground admin page.

### \n

By removing the escaping code.

## Testing Instructions

1. Check out the branch.
2. Install the plugin on a local WordPress site or use `wp-env`
3. On the local site update your password to be different from _password_
4. Start a sandbox (wp-admin > Tools > Start Sandbox)
5. Confirm that the sandbox loaded and that you are logged in
6. If you are using the default WP theme open the Sample page by clicking on the link in the header, if not open another page that has multiple paragraphs with line breaks between them.
7. Confirm that there are no `\n` characters



