### PR TITLE
WP-NOW: fix file uploads using multipart form data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,7 @@
 				"@rollup/plugin-url": "^8.0.1",
 				"@testing-library/react": "14.0.0",
 				"@tsconfig/docusaurus": "^1.0.5",
+				"@types/express-fileupload": "1.5.0",
 				"@types/file-saver": "^2.0.5",
 				"@types/jest": "^29.4.0",
 				"@types/node": "18.14.2",
@@ -12335,6 +12336,15 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/busboy": {
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-1.5.3.tgz",
+			"integrity": "sha512-YMBLFN/xBD8bnqywIlGyYqsNFXu6bsiY7h3Ae0kO17qEuTjsqeyYMRPSUDacIKIquws2Y6KjmxAyNx8xB3xQbw==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/chai": {
 			"version": "4.3.5",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
@@ -12411,6 +12421,16 @@
 				"@types/express-serve-static-core": "^4.17.33",
 				"@types/qs": "*",
 				"@types/serve-static": "*"
+			}
+		},
+		"node_modules/@types/express-fileupload": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@types/express-fileupload/-/express-fileupload-1.5.0.tgz",
+			"integrity": "sha512-Y9v88IC5ItAxkKwfnyIi1y0jSZwTMY4jqXUQLZ3jFhYJlLdRnN919bKBNM8jbVVD2cxywA/uEC1kNNpZQGwx7Q==",
+			"dev": true,
+			"dependencies": {
+				"@types/busboy": "*",
+				"@types/express": "*"
 			}
 		},
 		"node_modules/@types/express-serve-static-core": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
 		"@rollup/plugin-url": "^8.0.1",
 		"@testing-library/react": "14.0.0",
 		"@tsconfig/docusaurus": "^1.0.5",
+		"@types/express-fileupload": "1.5.0",
 		"@types/file-saver": "^2.0.5",
 		"@types/jest": "^29.4.0",
 		"@types/node": "18.14.2",

--- a/packages/wp-now/src/encode-as-multipart.ts
+++ b/packages/wp-now/src/encode-as-multipart.ts
@@ -1,5 +1,6 @@
 /**
  * Encodes the Express request with files into multipart/form-data request body.
+ * Adaptation of https://github.com/WordPress/wordpress-playground/blob/45bf16970867cc6f23738224dacf201905adcab6/packages/php-wasm/universal/src/lib/encode-as-multipart.ts
  */
 export async function encodeAsMultipart(req: Express.Request) {
 	const boundary = `----${Math.random().toString(36).slice(2)}`;

--- a/packages/wp-now/src/encode-as-multipart.ts
+++ b/packages/wp-now/src/encode-as-multipart.ts
@@ -1,0 +1,47 @@
+/**
+ * Encodes the Express request with files into multipart/form-data request body.
+ */
+export async function encodeAsMultipart(req: Express.Request) {
+	const boundary = `----${Math.random().toString(36).slice(2)}`;
+	const contentType = `multipart/form-data; boundary=${boundary}`;
+
+	const textEncoder = new TextEncoder();
+	const parts: (string | Uint8Array)[] = [];
+	const data = (req as any).body as Record<string, string>;
+	for (const [name, value] of Object.entries(data)) {
+		parts.push(`--${boundary}\r\n`);
+		parts.push(`Content-Disposition: form-data; name="${name}"`);
+		parts.push(`\r\n`);
+		parts.push(`\r\n`);
+		parts.push(value);
+		parts.push(`\r\n`);
+	}
+	const files = req.files;
+	for (const [name, value] of Object.entries(files)) {
+		if (!Array.isArray(value)) {
+			parts.push(`--${boundary}\r\n`);
+			parts.push(`Content-Disposition: form-data; name="${name}"`);
+			parts.push(`; filename="${value.name}"`);
+			parts.push(`\r\n`);
+			parts.push(`Content-Type: application/octet-stream`);
+			parts.push(`\r\n`);
+			parts.push(`\r\n`);
+			parts.push(value.data);
+			parts.push(`\r\n`);
+		}
+	}
+	parts.push(`--${boundary}--\r\n`);
+
+	const length = parts.reduce((acc, part) => acc + part.length, 0);
+	const bytes = new Uint8Array(length);
+	let offset = 0;
+	for (const part of parts) {
+		bytes.set(
+			typeof part === 'string' ? textEncoder.encode(part) : part,
+			offset
+		);
+		offset += part.length;
+	}
+
+	return { bytes, contentType };
+}

--- a/packages/wp-now/src/start-server.ts
+++ b/packages/wp-now/src/start-server.ts
@@ -10,29 +10,16 @@ import { NodePHP } from '@php-wasm/node';
 import startWPNow from './wp-now';
 import { output } from './output';
 import { addTrailingSlash } from './add-trailing-slash';
+import { encodeAsMultipart } from './encode-as-multipart';
 
-function requestBodyToMultipartFormData(json, boundary) {
-	let multipartData = '';
-	const eol = '\r\n';
-
-	for (const key in json) {
-		multipartData += `--${boundary}${eol}`;
-		multipartData += `Content-Disposition: form-data; name="${key}"${eol}${eol}`;
-		multipartData += `${json[key]}${eol}`;
-	}
-
-	multipartData += `--${boundary}--${eol}`;
-	return multipartData;
-}
-
-const requestBodyToString = async (req) =>
+const requestBodyToBytes = async (req): Promise<Uint8Array> =>
 	await new Promise((resolve) => {
-		let body = '';
+		const body = [];
 		req.on('data', (chunk) => {
-			body += chunk.toString(); // convert Buffer to string
+			body.push(chunk);
 		});
 		req.on('end', () => {
-			resolve(body);
+			resolve(Buffer.concat(body));
 		});
 	});
 
@@ -74,34 +61,23 @@ export async function startServer(
 				}
 			}
 
-			const body = requestHeaders['content-type']?.startsWith(
-				'multipart/form-data'
-			)
-				? requestBodyToMultipartFormData(
-						req.body,
-						requestHeaders['content-type'].split('; boundary=')[1]
-				  )
-				: await requestBodyToString(req);
-
+			let body: Uint8Array;
+			if (
+				requestHeaders['content-type']?.startsWith(
+					'multipart/form-data'
+				)
+			) {
+				const multipart = await encodeAsMultipart(req);
+				body = multipart.bytes;
+				requestHeaders['content-type'] = multipart.contentType;
+			} else {
+				body = await requestBodyToBytes(req);
+			}
 			const data = {
 				url: req.url,
 				headers: requestHeaders,
 				method: req.method as HTTPMethod,
-				files: Object.fromEntries(
-					Object.entries((req as any).files || {}).map<any>(
-						([key, file]: any) => [
-							key,
-							{
-								key,
-								name: file.name,
-								size: file.size,
-								type: file.mimetype,
-								arrayBuffer: () => file.data.buffer,
-							},
-						]
-					)
-				),
-				body: body as string,
+				body,
 			};
 			const resp = await php.request(data);
 			res.statusCode = resp.httpStatusCode;


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

- Fixes https://github.com/WordPress/playground-tools/issues/202
- Fixes https://meta.trac.wordpress.org/ticket/7535

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->
This PR fixes the ability to upload Images and any file in general using wp-now.


## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

* On https://github.com/WordPress/wordpress-playground/pull/1018/files#diff-71ce1e60e1e8bfb1b2301d9c49d4bd835b28bf65f812e7636c1cae70e4cb5d92 , Playground core v0.6.3 removed the custom `files` property from the request handler.
* wp-now updated the dependencies on https://github.com/WordPress/playground-tools/pull/157 which broke the ability to upload files using the multipart form.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* In the same PR, Playground core introduced the function `encodeAsMultipart` which was used as a base to fix the issue in this PR.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->
* Run `nvm use && npm install && npm start`
* Run `npx nx build wp-now && node dist/packages/wp-now/cli.js start`
* Open http://localhost:8881/wp-admin/upload.php
* Click on `Add New Media File`.
* Select any image or valid file like mp3 or mp4.
* Observe the file has been uploaded correctly to the Media Library.



https://github.com/WordPress/playground-tools/assets/779993/f78783f3-8504-456c-bdde-f660837e9d0b

