### PR TITLE
WP-NOW: update documentation adding quickstart section and updating GIF

### DIFF
--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -4,7 +4,7 @@
 
 It uses automatic mode detection to provide a fast setup process, regardless of whether you're working on a plugin or an entire site. You can easily switch between PHP and WordPress versions with just a configuration argument. Under the hood, `wp-now` is powered by WordPress Playground and only requires Node.js.
 
-![Demo GIF of wp-now](https://github.com/WordPress/wordpress-playground/assets/36432/474ecb85-d789-4db9-b820-a19c25da79ad)
+![Demo GIF of wp-now](https://github.com/WordPress/playground-tools/assets/779993/5a2da682-977f-4ca3-80d3-f9e4d773a887)
 
 ## Table of Contents
 

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -4,7 +4,7 @@
 
 It uses automatic mode detection to provide a fast setup process, regardless of whether you're working on a plugin or an entire site. You can easily switch between PHP and WordPress versions with just a configuration argument. Under the hood, `wp-now` is powered by WordPress Playground and only requires Node.js.
 
-![Demo GIF of wp-now](https://github.com/WordPress/playground-tools/assets/779993/5a2da682-977f-4ca3-80d3-f9e4d773a887)
+![Demo GIF of wp-now](https://github.com/WordPress/playground-tools/assets/779993/302669c3-925e-430f-9e74-c433e67798cd)
 
 ## Quickstart
 

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -53,7 +53,7 @@ Node 18 is the minimum supported version. Node 20 is required for Blueprint supp
 
 <img src="../../assets/wp-now-basics-diagram.png" width="600">
 
-To run `wp-now` with one command, you can use [npx](https://docs.npmjs.com/cli/v10/commands/npx):
+To run `wp-now` with one command, you can use [npx](https://docs.npmjs.com/cli/v10/commands/npx). This is our recommended way to use `wp-now` as it doesn't require any installation or setup.:
 
 ```bash
 npx @wp-now/wp-now start

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -6,8 +6,29 @@ It uses automatic mode detection to provide a fast setup process, regardless of 
 
 ![Demo GIF of wp-now](https://github.com/WordPress/playground-tools/assets/779993/5a2da682-977f-4ca3-80d3-f9e4d773a887)
 
+## Quickstart
+
+### Launching wp-now in a Plugin or Theme Directory
+
+Running wp-now is as simple as accessing your plugin or theme directory and starting wp-now.
+
+```bash
+cd my-plugin-or-theme-directory
+npx @wp-now/wp-now start
+```
+
+### Launching wp-now in the wp-content Directory with Options
+
+You can also start wp-now from any wp-content folder. In this example, we pass parameters to change the PHP and WordPress versions and apply a blueprint file.
+
+```bash
+cd my-wordpress-folder/wp-content
+npx @wp-now/wp-now start  --wp=5.9 --php=7.4 --blueprint=path/to/blueprint-example.json
+```
+
 ## Table of Contents
 
+-   [Quickstart](#quickstart)
 -   [Requirements](#requirements)
 -   [Usage](#usage)
     -   [Automatic Modes](#automatic-modes)


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->
* Update wp-now Readme for better simplicity and highlighting `npx` usage.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- It was a great suggestion from https://github.com/WordPress/playground-tools/issues/194

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->

Confirm the README looks good.

https://github.com/WordPress/playground-tools/blob/aac36a5676ba9d5da1d2d44ca1590337017c3ac8/packages/wp-now/README.md

![wp-now-quickstart](https://github.com/WordPress/playground-tools/assets/779993/302669c3-925e-430f-9e74-c433e67798cd)


