### PR TITLE
WP-NOW: Add wp-cli integration

### DIFF
--- a/packages/wp-now/src/execute-wp-cli.ts
+++ b/packages/wp-now/src/execute-wp-cli.ts
@@ -26,6 +26,7 @@ export async function executeWPCli(args: string[]) {
 
 	try {
 		const vfsWpCliPath = '/wp-cli/wp-cli.phar';
+		php.mount('.', '/local'); // mount current dir to run "wp-now wp eval-file /local/foo.php"
 		php.mount(dirname(getWpCliPath()), dirname(vfsWpCliPath));
 		await php.cli([
 			'php',

--- a/packages/wp-now/src/run-cli.ts
+++ b/packages/wp-now/src/run-cli.ts
@@ -152,24 +152,24 @@ export async function runCli() {
 					process.exit(error.status || -1);
 				}
 			}
-	)
-	.command(
-		'wp',
-		'Run the wp command passing the arguments for wp cli',
-		(yargs) => {
-			return yargs.strict(false);
-		},
-		async () => {
-			// 0: node, 1: wp-now, 2: wp, 3: [wp-cli options...]
-			const args = process.argv.slice(3);
-			try {
-				await executeWPCli(args);
-				process.exit(0);
-			} catch (error) {
-				process.exit(error.status || -1);
+		)
+		.command(
+			'wp',
+			'Run the wp command passing the arguments for wp cli',
+			(yargs) => {
+				return yargs.strict(false);
+			},
+			async () => {
+				// 0: node, 1: wp-now, 2: wp, 3: [wp-cli options...]
+				const args = process.argv.slice(3);
+				try {
+					await executeWPCli(args);
+					process.exit(0);
+				} catch (error) {
+					process.exit(error.status || -1);
+				}
 			}
-		}
-	)
+		)
 		.demandCommand(1, 'You must provide a valid command')
 		.help()
 		.alias('h', 'help')

--- a/packages/wp-now/src/run-cli.ts
+++ b/packages/wp-now/src/run-cli.ts
@@ -8,6 +8,7 @@ import { spawn, SpawnOptionsWithoutStdio } from 'child_process';
 import { executePHP } from './execute-php';
 import { output } from './output';
 import { isGitHubCodespace } from './github-codespaces';
+import { executeWPCli } from './execute-wp-cli';
 
 function startSpinner(message: string) {
 	process.stdout.write(`${message}...\n`);
@@ -151,7 +152,24 @@ export async function runCli() {
 					process.exit(error.status || -1);
 				}
 			}
-		)
+	)
+	.command(
+		'wp',
+		'Run the wp command passing the arguments for wp cli',
+		(yargs) => {
+			return yargs.strict(false);
+		},
+		async () => {
+			// 0: node, 1: wp-now, 2: wp, 3: [wp-cli options...]
+			const args = process.argv.slice(3);
+			try {
+				await executeWPCli(args);
+				process.exit(0);
+			} catch (error) {
+				process.exit(error.status || -1);
+			}
+		}
+	)
 		.demandCommand(1, 'You must provide a valid command')
 		.help()
 		.alias('h', 'help')

--- a/packages/wp-now/src/tests/wp-cli-eval-file/total-posts.php
+++ b/packages/wp-now/src/tests/wp-cli-eval-file/total-posts.php
@@ -1,0 +1,10 @@
+<?php
+function count_all_published_posts() {
+    $count_posts = wp_count_posts();
+    $published_posts = $count_posts->publish;
+    return $published_posts;
+}
+
+$published_post_count = count_all_published_posts();
+echo 'Total published posts: ' . $published_post_count;
+?>

--- a/packages/wp-now/src/tests/wp-now.spec.ts
+++ b/packages/wp-now/src/tests/wp-now.spec.ts
@@ -845,4 +845,16 @@ describe('wp-cli command', () => {
 		await executeWPCli(['cli', 'version']);
 		expect(output).toMatch(/WP-CLI (\d\.?)+/i);
 	});
+
+	/**
+	 * Test wp-cli eval-file works correctly.
+	 * We will use the context of Playground mode.
+	 */
+	test('wp-cli eval-file works correctly', async () => {
+		await executeWPCli([
+			'eval-file',
+			'/local/packages/wp-now/src/tests/wp-cli-eval-file/total-posts.php',
+		]);
+		expect(output).toMatch('Total published posts: 1');
+	});
 });


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

- Closes: https://github.com/WordPress/playground-tools/issues/25

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->
Brings `wp-cli` execution to `wp-now` with the current site context.
The new command will be `wp-now wp ...`
I'm open to other command names, like `cli`.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

wp-cli is a handy tool for all WordPress developers opening a wide range of automatizations. 

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

wp-cli was intentionally removed until the Playground was mature enough to support a wide range of operations.
I added a new command that calls `executeWPCli`, which downloads the phar file and mounts the current directory to make easier the execution of local files with `eval-file`.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->
1. Run `nvm use && npm install && npx nx build wp-now`
2. Run `npx nx run wp-now:test`
3. Observe the tests pass
4. Run `node dist/packages/wp-now/cli.js wp eval-file /./foo.php`
5. Run `node dist/packages/wp-now/cli.js wp cli version`
6. Run other wp-cli commands
7. Confirm wp-cli runs as expected
