### PR TITLE
WP-NOW: Remove message about node v20 limitation for blueprints

### DIFF
--- a/packages/wp-now/public/with-node-version.js
+++ b/packages/wp-now/public/with-node-version.js
@@ -5,12 +5,8 @@ import fs from 'fs';
 
 // Set the minimum required/supported version of node here.
 
-// Check if `--blueprint=` is passed in proccess.argv
-const hasBlueprint = process.argv.some((arg) => arg.startsWith('--blueprint='));
-
 const minimum = {
-	// `--blueprint=` requires node v20
-	major: hasBlueprint ? 20 : 18,
+	major: 18,
 	minor: 0,
 	patch: 0,
 };
@@ -40,9 +36,8 @@ function meetsMinimumVersion(minimum, [major, minor, patch]) {
 }
 
 if (!meetsMinimumVersion(minimum, [major, minor, patch])) {
-	const extra = hasBlueprint ? ' when --blueprint=<file> is used' : '';
 	console.error(
-		`This script is requires node version v${minimum.major}.${minimum.minor}.${minimum.patch} or above${extra}; found ${process.version}`
+		`This script is requires node version v${minimum.major}.${minimum.minor}.${minimum.patch} or above; found ${process.version}`
 	);
 	process.exit(1);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->

Remove message that asks for Node v20 when`--blueprint` param is present.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Since the polyfills were implemented on https://github.com/WordPress/wordpress-playground/pull/882 , blueprints can be executed on Node v18

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->

* Create a new blueprint file `b.json` with a valid blueprint like:
```
{
    "landingPage": "/wp-admin/",
    "features": {
        "networking": true
    },
    "steps": [
        {
            "step": "login",
            "username": "admin",
            "password": "password"
        }
    ]
}
```
* Run `nvm use && npm install && npx nx run wp-now:build` # nvm use will set the node version 18.18.2
* Run `node dist/packages/wp-now/with-node-version.js start --blueprint=b.json`
* Observe the blueprint runs as expected and there is no the following error `This script is requires node version v20.0.0 or above when --blueprint=<file> is used; found v18.18.2`