### PR TITLE
Playground plugin: export data and catch load errors

### DIFF
--- a/packages/playground/README.txt
+++ b/packages/playground/README.txt
@@ -40,6 +40,7 @@ Your site is cloned in Playground by copying all the files and a database into W
 
 - Start a sandbox of your site
 - Preview a plugin installation from the WordPress.org repository
+- Export Playground snapshots using Tools > Export
 
 == Resources ==
 
@@ -58,6 +59,9 @@ For any issues or questions about the WordPress Playground plugin, please open a
 The WordPress Playground Plugin is licensed under the GNU General Public License v2.0. This is a free software license that allows you to use, modify, and distribute the software, provided you adhere to its terms and conditions.
 
 == Changelog ==
+
+= 0.1.0 =
+* Add export support and error handling.
 
 = 0.0.5 =
 * Initial release.

--- a/packages/playground/README.txt
+++ b/packages/playground/README.txt
@@ -3,7 +3,7 @@ Contributors: wordpressdotorg, antoniosejas, berislavgrgicak, zieladam
 Tags: playground, staging, sandbox
 Requires at least: 6.0
 Tested up to: 6.4
-Stable tag: 0.0.4
+Stable tag: 0.1.0
 Requires PHP: 7.0
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/packages/playground/assets/js/playground.js
+++ b/packages/playground/assets/js/playground.js
@@ -1,78 +1,94 @@
 (async () => {
-	const { startPlaygroundWeb } = await import(
-		playground.playgroundPackageUrl
-	);
-	const blueprint = {
-		features: {
-			networking: true,
-		},
-		preferredVersions: {
-			wp: playground.wpVersion,
-			php: playground.phpVersion,
-		},
-		steps: [
-			{
-				step: 'unzip',
-				zipFile: {
-					resource: 'url',
-					url: playground.zipUrl,
-				},
-				extractToPath: '/wordpress',
-			},
-			{
-				step: 'runSql',
-				sql: {
-					resource: 'vfs',
-					path: '/wordpress/schema/_Schema.sql',
-				},
-			},
-		],
+	const onError = (error) => {
+		alert(`Playground couldn’t start. Please check the browser console for more information. ${error}`);
+		const backButton = document.getElementById('goBack');
+		if (backButton) {
+			backButton.click();
+		}
 	};
 
-	if (playground.pluginSlug) {
-		blueprint.steps.push({
-			step: 'installPlugin',
-			pluginZipFile: {
-				resource: 'wordpress.org/plugins',
-				slug: playground.pluginSlug,
-			},
-			options: {
-				activate: true,
-			},
-		});
+	if (!window.playground) {
+		onError('Playground script data not found.');
+		return;
 	}
+	try {
+		const { startPlaygroundWeb } = await import(
+			playground.playgroundPackageUrl
+		);
+		const blueprint = {
+			features: {
+				networking: true,
+			},
+			preferredVersions: {
+				wp: playground.wpVersion,
+				php: playground.phpVersion,
+			},
+			steps: [
+				{
+					step: 'unzip',
+					zipFile: {
+						resource: 'url',
+						url: playground.zipUrl,
+					},
+					extractToPath: '/wordpress',
+				},
+				{
+					step: 'runSql',
+					sql: {
+						resource: 'vfs',
+						path: '/wordpress/schema/_Schema.sql',
+					},
+				},
+			],
+		};
 
-	const client = await startPlaygroundWeb({
-		iframe: document.getElementById('wp-playground'),
-		remoteUrl: playground.playgroundRemoteUrl,
-		blueprint,
-	});
-
-	await client.isReady();
-
-	// Login as the current user without a password
-	await client.writeFile(
-		'/wordpress/playground-login.php',
-		`<?php
-		require_once( dirname( __FILE__ ) . '/wp-load.php' );
-		if ( is_user_logged_in() ) {
-			return;
+		if (playground.pluginSlug) {
+			blueprint.steps.push({
+				step: 'installPlugin',
+				pluginZipFile: {
+					resource: 'wordpress.org/plugins',
+					slug: playground.pluginSlug,
+				},
+				options: {
+					activate: true,
+				},
+			});
 		}
-		$user = get_user_by( 'id', ${playground.userId} );
-		if( $user ) {
-			wp_set_current_user( $user->ID, $user->user_login );
-			wp_set_auth_cookie( $user->ID );
-			do_action( 'wp_login', $user->user_login, $user );
-		}`
-	);
-	await client.request({
-		url: '/playground-login.php',
-	});
-	await client.unlink('/wordpress/playground-login.php');
 
-	if (playground.pluginSlug) {
-		await client.goTo('/wp-admin/plugins.php');
-	} else {
-		await client.goTo('/wp-admin/');
+		const client = await startPlaygroundWeb({
+			iframe: document.getElementById('wp-playground'),
+			remoteUrl: playground.playgroundRemoteUrl,
+			blueprint,
+		});
+
+		await client.isReady();
+
+		// Login as the current user without a password
+		await client.writeFile(
+			'/wordpress/playground-login.php',
+			`<?php
+			require_once( dirname( __FILE__ ) . '/wp-load.php' );
+			if ( is_user_logged_in() ) {
+				return;
+			}
+			$user = get_user_by( 'id', ${playground.userId} );
+			if( $user ) {
+				wp_set_current_user( $user->ID, $user->user_login );
+				wp_set_auth_cookie( $user->ID );
+				do_action( 'wp_login', $user->user_login, $user );
+			}`
+		);
+		await client.request({
+			url: '/playground-login.php',
+		});
+		await client.unlink('/wordpress/playground-login.php');
+
+		if (playground.pluginSlug) {
+			await client.goTo('/wp-admin/plugins.php');
+		} else {
+			await client.goTo('/wp-admin/');
+		}
+	} catch (error) {
+		onError(error);
 	}
 })();

--- a/packages/playground/assets/js/playground.js
+++ b/packages/playground/assets/js/playground.js
@@ -36,7 +36,7 @@
 					step: 'runSql',
 					sql: {
 						resource: 'vfs',
-						path: '/wordpress/schema/_Schema.sql',
+						path: '/wordpress/wp-content/database/database.sql',
 					},
 				},
 			],

--- a/packages/playground/playground.php
+++ b/packages/playground/playground.php
@@ -26,6 +26,7 @@ define('PLAYGROUND_PHP_VERSION', implode('.', sscanf(phpversion(), '%d.%d')));
 
 require __DIR__ . '/vendor/autoload.php';
 require __DIR__ . '/src/playground-zip.php';
+require __DIR__ . '/src/playground-export.php';
 
 add_action('admin_menu', __NAMESPACE__ . '\plugin_menu');
 add_action('admin_init', __NAMESPACE__ . '\init');
@@ -91,13 +92,6 @@ function get_download_page_url()
  */
 function plugins_loaded()
 {
-	if (!is_admin()) {
-		return;
-	}
-	if (!current_user_can(ADMIN_PAGE_CAPABILITY)) {
-		return;
-	}
-
 	global $pagenow;
 	if ('admin.php' !== $pagenow) {
 		return;
@@ -110,6 +104,21 @@ function plugins_loaded()
 
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	if (!isset($_GET['download'])) {
+		return;
+	}
+
+	download_snapshot();
+}
+
+/**
+ * Download the Playground snapshot.
+ */
+function download_snapshot()
+{
+	if (!is_admin()) {
+		return;
+	}
+	if (!current_user_can(ADMIN_PAGE_CAPABILITY)) {
 		return;
 	}
 

--- a/packages/playground/playground.php
+++ b/packages/playground/playground.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://github.com/WordPress/playground-tools/tree/trunk/packages/playground
  * Description: Packages your WordPress install and sends it to Playground.
  * Author: WordPress Contributors
- * Version: 0.0.4
+ * Version: 0.1.0
  * Requires PHP: 8.0
  * License: GPLv2
  * Text Domain: playground
@@ -168,7 +168,7 @@ function plugin_install_action_links($action_links, $plugin)
 		esc_attr(
 			sprintf(
 				/* translators: %s: Plugin name. */
-				_x('Preview %s now', 'playground'),
+				__('Preview %s now', 'playground'),
 				$plugin['name']
 			)
 		),

--- a/packages/playground/playground.php
+++ b/packages/playground/playground.php
@@ -83,7 +83,7 @@ function get_download_page_url()
 		[
 			'download' => 1,
 		],
-		admin_url('admin.php?page=' . PLAYGROUND_ADMIN_PAGE_SLUG)
+		admin_url('tools.php?page=' . PLAYGROUND_ADMIN_PAGE_SLUG)
 	);
 }
 
@@ -93,7 +93,7 @@ function get_download_page_url()
 function plugins_loaded()
 {
 	global $pagenow;
-	if ('admin.php' !== $pagenow) {
+	if ('tools.php' !== $pagenow) {
 		return;
 	}
 
@@ -167,7 +167,7 @@ function plugin_install_action_links($action_links, $plugin)
 		[
 			'pluginSlug' => esc_attr($plugin['slug']),
 		],
-		admin_url('admin.php?page=' . PLAYGROUND_ADMIN_PAGE_SLUG)
+		admin_url('tools.php?page=' . PLAYGROUND_ADMIN_PAGE_SLUG)
 	);
 
 	$preview_button = sprintf(

--- a/packages/playground/src/playground-db.php
+++ b/packages/playground/src/playground-db.php
@@ -70,7 +70,7 @@ function zip_database($zip)
 			);
 		}
 	}
-	$zip->addFile('schema/_Schema.sql', implode("\n", $sql_dump));
+	$zip->addFile('wp-content/database/database.sql', implode("\n", $sql_dump));
 }
 
 /**

--- a/packages/playground/src/playground-export.php
+++ b/packages/playground/src/playground-export.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace WordPress\Playground;
+
+defined('ABSPATH') || exit;
+
+const EXPORT_SLUG = 'playground-snapshot';
+
+add_action('export_filters',  __NAMESPACE__ . '\add_playground_snapshot_filters');
+add_action('export_wp', __NAMESPACE__ . '\export_playground_snapshot');
+
+/**
+ * Add an export filter for the Playground snapshot.
+ *
+ * @return void
+ */
+function add_playground_snapshot_filters()
+{
+?>
+    <p>
+        <label for="<?php echo esc_attr(EXPORT_SLUG); ?>">
+            <input type="radio" value="<?php echo esc_attr(EXPORT_SLUG); ?>" name="content" id="<?php echo esc_attr(EXPORT_SLUG); ?>" />
+            <?php _e('Playground snapshot', 'playground'); ?>
+        </label>
+    </p>
+<?php
+}
+
+/**
+ * Download the Playground snapshot if requested.
+ *
+ * @param array $args
+ * @return void
+ */
+function export_playground_snapshot($args)
+{
+    if (!isset($args['content'])) {
+        return;
+    }
+
+    if ($args['content'] !== EXPORT_SLUG) {
+        return;
+    }
+
+    download_snapshot();
+    wp_die();
+}

--- a/packages/playground/templates/playground-page.php
+++ b/packages/playground/templates/playground-page.php
@@ -25,6 +25,6 @@ defined('ABSPATH') || exit;
         </a>
     </div>
     <div id="wp-playground-main-area">
-        <iframe id="wp-playground"></iframe>
+        <iframe credentialless id="wp-playground"></iframe>
     </div>
 </div>


### PR DESCRIPTION
Fixes #213 #208

<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

This PR adds support for exporting Playground data and implements an error modal when Playground fails to load.

## Why?

We would like to allow users to export snapshots of their sites that can later be imported into Playground (a feature in Playground isn't implemented).

Some users reported errors like CORS issues and we need to ensure users have a next step to debug the issue. 

## How?

Playground snapshot is now an option in Tools > Export. 

By catching errors while Playground is loading and displaying an alert. 

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
1. Check out the branch.
2. Start a site with the plugin running for example by using wp-env
```
cd packages/playground
wp-env start
```
3. Go to wp-admin > Tools > Export
4. Select _Playground snapshot_ and export it
5. Ensure that the downloaded zip contains data
6. Add one of the headers to the top of `playground.php` 
```
header("Content-Security-Policy: default-src 'self'");

header("Content-Security-Policy: default-src 'self' style-src 'self' 'unsafe-inline' 'unsafe-eval'; script-src 'self' 'unsafe-inline' 'unsafe-eval';");
```
7. Try starting a sandbox
8. Confirm that you see an error alert

