### PR TITLE
wp-now: WebContainer support fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
 				"@php-wasm/universal": "0.6.13",
 				"@php-wasm/web": "0.6.13",
 				"@uiw/react-codemirror": "^4.21.20",
+				"@webcontainer/env": "1.1.1",
 				"@wp-playground/blueprints": "0.6.13",
 				"classnames": "^2.3.2",
 				"comlink": "^4.4.1",
@@ -14278,6 +14279,11 @@
 				"@webassemblyjs/ast": "1.11.6",
 				"@xtuc/long": "4.2.2"
 			}
+		},
+		"node_modules/@webcontainer/env": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@webcontainer/env/-/env-1.1.1.tgz",
+			"integrity": "sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng=="
 		},
 		"node_modules/@webpack-cli/configtest": {
 			"version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"@php-wasm/universal": "0.6.13",
 		"@php-wasm/web": "0.6.13",
 		"@uiw/react-codemirror": "^4.21.20",
+		"@webcontainer/env": "1.1.1",
 		"@wp-playground/blueprints": "0.6.13",
 		"classnames": "^2.3.2",
 		"comlink": "^4.4.1",

--- a/packages/wp-now/src/config.ts
+++ b/packages/wp-now/src/config.ts
@@ -12,6 +12,7 @@ import { portFinder } from './port-finder';
 import { isValidWordPressVersion } from './wp-playground-wordpress';
 import getWpNowPath from './get-wp-now-path';
 import { DEFAULT_PHP_VERSION, DEFAULT_WORDPRESS_VERSION } from './constants';
+import { isWebContainer, HostURL } from '@webcontainer/env';
 
 export interface CliOptions {
 	php?: string;
@@ -74,6 +75,9 @@ async function getAbsoluteURL() {
 	const port = await portFinder.getOpenPort();
 	if (isGitHubCodespace) {
 		return getCodeSpaceURL(port);
+	}
+	if (isWebContainer()) {
+		return HostURL.parse('http://localhost:' + port).toString();
 	}
 
 	if (absoluteUrlFromBlueprint) {

--- a/packages/wp-now/src/start-server.ts
+++ b/packages/wp-now/src/start-server.ts
@@ -7,6 +7,7 @@ import compressible from 'compressible';
 import fileUpload from 'express-fileupload';
 import { portFinder } from './port-finder';
 import { NodePHP } from '@php-wasm/node';
+import { isWebContainer } from '@webcontainer/env';
 import startWPNow from './wp-now';
 import { output } from './output';
 import { addTrailingSlash } from './add-trailing-slash';
@@ -79,6 +80,18 @@ export async function startServer(
 				method: req.method as HTTPMethod,
 				body,
 			};
+
+			if (isWebContainer()) {
+				// Unlike a typical Nginx or reverse proxy setup, WebContainers
+				// overwrite the Host header sent by the browser with a localhost
+				// URL. However, WordPress detects when the Host header is different
+				// from the stored site URL and redirects back to the site URL.
+				// For WordPress to work, we need to make sure the host and origin
+				// headers contain  the public-facing site URL.
+				data.headers['host'] = new URL(options.absoluteUrl).host;
+				data.headers['origin'] = options.absoluteUrl;
+			}
+
 			const resp = await php.request(data);
 			res.statusCode = resp.httpStatusCode;
 			Object.keys(resp.headers).forEach((key) => {


### PR DESCRIPTION
Improvements to https://github.com/WordPress/playground-tools/pull/150 with fixes related to updates for wp-now in WebContainer

Can be retargetting to `trunk` if you want to close the other PR

## Testing Instructions

Visit https://stackblitz.com/edit/node and run 

```bash
npx @wp-now/wp-now@some-version start
```

WP-Now should load in your browser