### PR TITLE
WP-NOW: Investigate release wp-now workflow

### DIFF
--- a/.github/workflows/release-wp-now.yml
+++ b/.github/workflows/release-wp-now.yml
@@ -36,6 +36,7 @@ jobs:
               run: |
                   git config --global user.name "deployment_bot"
                   git config --global user.email "deployment_bot@users.noreply.github.com"
+                  git remote set-url origin https://${{ secrets.GH_ACTOR }}:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}
             - name: Authenticate with Registry
               run: |
                   echo "@wp-now:registry=https://registry.npmjs.org/" >> ~/.npmrc


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

- Related to https://github.com/WordPress/playground-tools/pull/190

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->

Try to fix the `Release wp-now workflow`. Currently, it's not working: https://github.com/WordPress/playground-tools/actions/workflows/release-wp-now.yml


## Why?

Currently, it fails with the following error:

```
lerna info auto-confirmed 
lerna info execute Skipping releases
lerna verb version wordpress-playground has no lockfile. Skipping lockfile update.
lerna verb version @wp-now/wp-now has no lockfile. Skipping lockfile update.
lerna verb version Updating root package-lock.json
lerna verb git [ 'commit', '-m', 'v0.1.68' ]
lerna verb git [ 'tag', 'v0.1.68', '-m', 'v0.1.68' ]
lerna info git Pushing tags...
lerna ERR! Error: Command failed with exit code 128: git push --follow-tags --no-verify --atomic origin trunk
lerna ERR! fatal: could not read Username for 'https://github.com/': No such device or address
lerna ERR!     at makeError (/home/runner/work/playground-tools/playground-tools/node_modules/execa/lib/error.js:60:11)
lerna ERR!     at handlePromise (/home/runner/work/playground-tools/playground-tools/node_modules/execa/index.js:118:26)
lerna ERR! lerna Command failed with exit code 128: git push --follow-tags --no-verify --atomic origin trunk
lerna ERR! lerna fatal: could not read Username for 'https://github.com/': No such device or address
```

[Reference](https://github.com/WordPress/playground-tools/actions/runs/8631282863/job/23659360539)

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I've discovered a missing line compared with [wordpress-playground/.github/workflows/publish-npm-packages.yml](https://github.com/WordPress/wordpress-playground/blob/68a91861e3f6abb26606c6ef4b162981d3619615/.github/workflows/publish-npm-packages.yml#L44) , which sets the GitHub origin URL with `username:token`

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->
1. Hard to test until it's merged and the action works.