### PR TITLE
Playground plugin: tweak the top toolbar

### DIFF
--- a/packages/playground/assets/css/playground.css
+++ b/packages/playground/assets/css/playground.css
@@ -14,8 +14,8 @@
 .tools_page_playground #wpbody {
 	position: initial;
 }
-.tools_page_playground #wpadminbar {
-	display: none;
+html.wp-toolbar {
+	padding: inherit;
 }
 
 #wp-playground-toolbar {

--- a/packages/playground/assets/css/playground.css
+++ b/packages/playground/assets/css/playground.css
@@ -20,9 +20,8 @@
 
 #wp-playground-toolbar {
 	background-color: #fff7cc;
-	font-family: "Andale mono", Helvetica, Monospace, Arial;
-	font-weight: 600;
-	padding: 0.5em;
+	font-weight: 500;
+	padding: 0.3em 0.5em;
 	display: flex;
 	gap: 1rem;
 	align-items: center;
@@ -35,17 +34,12 @@
 	transform: translateY(-100%);
 }
 
-#wp-playground-toolbar > a {
-	padding: 0.2rem;
-	color: #1a5687;
-	border: 1px solid;
-	border-radius: 5px;
-	text-decoration: none;
+#wp-playground-toolbar > p {
+	margin: 0;
 }
 
-#wp-playground-toolbar > a:hover {
-	background-color: #1a5687;
-	color: #fff7cc;
+#wp-playground-toolbar > a {
+	color: #1a5687;
 }
 
 #wp-playground-main-area {

--- a/packages/playground/assets/css/playground.css
+++ b/packages/playground/assets/css/playground.css
@@ -19,13 +19,12 @@
 }
 
 #wp-playground-toolbar {
-	background-color: #eaaa00;
-	font-weight: bold;
-	text-align: center;
-	font-size: 1rem;
-	padding: 0.75em;
+	background-color: #fff7cc;
+	font-family: "Andale mono", Helvetica, Monospace, Arial;
+	font-weight: 600;
+	padding: 0.5em;
 	display: flex;
-	flex-direction: row;
+	gap: 1rem;
 	align-items: center;
 	justify-content: center;
 	box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
@@ -37,8 +36,16 @@
 }
 
 #wp-playground-toolbar > a {
-	text-transform: capitalize;
-	padding: 0 0.5rem;
+	padding: 0.2rem;
+	color: #1a5687;
+	border: 1px solid;
+	border-radius: 5px;
+	text-decoration: none;
+}
+
+#wp-playground-toolbar > a:hover {
+	background-color: #1a5687;
+	color: #fff7cc;
 }
 
 #wp-playground-main-area {

--- a/packages/playground/templates/playground-page.php
+++ b/packages/playground/templates/playground-page.php
@@ -6,25 +6,25 @@ defined('ABSPATH') || exit;
 ?>
 <div id="wp-playground-wrapper">
     <div id="wp-playground-toolbar">
-        <span>
+        <p>
             <?php
             echo esc_attr(
                 sprintf(
                     // translators: %s: Site name.
                     __(
-                        'WordPress Playground preview for %s',
+                        'WordPress Playground preview of %s',
                         'playground'
                     ),
                     get_bloginfo('name')
                 )
             );
             ?>
-        </span>
+        </p>
         <a href="<?php echo esc_url(admin_url()); ?>" id="goBack">
-            <?php esc_attr_e('Go Back', 'playground'); ?>
+            <?php esc_attr_e('Back', 'playground'); ?>
         </a>
     </div>
     <div id="wp-playground-main-area">
-        <iframe credentialless id="wp-playground"></iframe>
+        <iframe credentialless id="wp-playground" title="WordPress Playground Sandbox"></iframe>
     </div>
 </div>

--- a/packages/playground/templates/playground-page.php
+++ b/packages/playground/templates/playground-page.php
@@ -20,11 +20,11 @@ defined('ABSPATH') || exit;
             );
             ?>
         </p>
-        <a href="<?php echo esc_url(admin_url()); ?>" id="goBack">
+        <a href="<?php echo esc_url(admin_url()); ?>" id="goBack" class="button">
             <?php esc_attr_e('Back', 'playground'); ?>
         </a>
     </div>
     <div id="wp-playground-main-area">
-        <iframe credentialless id="wp-playground" title="WordPress Playground Sandbox"></iframe>
+        <iframe credentialless id="wp-playground" title="<?php _e('WordPress Playground Sandbox', 'playground'); ?>"></iframe>
     </div>
 </div>


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->
This PR changes the message displayed on the top toolbar of a Playground Sandbox. The changes include text, markup, and styles.

The following screenshot demonstrates the changes:
- Top: current toolbar
- Middle: new toolbar
- Bottom: new toolbar when hovering over the **Back** “button”
<img width="723" alt="top-toolbar" src="https://github.com/WordPress/playground-tools/assets/63248335/074c758c-3884-4849-8072-dae17751d932">

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
1. The current color palette is inaccessible (insufficient color contrast).
2. The styles aren't consistent with Playground's existing notice (see [`experimental-notice`](https://github.com/WordPress/wordpress-playground/blob/02a528dd04996d7c9c2a1fdae143ee39c60933f0/packages/playground/website/src/components/browser-chrome/style.module.css#L9)).
3. The copy could be clearer.
4. The `<iframe>` element had no title (required for accessibility reasons).

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I updated two files: the CSS and PHP template:
- Copied [the relevant styles](https://github.com/WordPress/wordpress-playground/blob/02a528dd04996d7c9c2a1fdae143ee39c60933f0/packages/playground/website/src/components/browser-chrome/style.module.css#L12-L13) from the existing notice.
- Updated the link color to pass AA and AAA:
<img width="400" alt="contrast-ratio" src="https://github.com/WordPress/playground-tools/assets/63248335/a3f5167a-41d3-4c78-a201-5731b8a0591a">

- Added styles for the **Back** “button” hover state.
- Changed the HTML markup and copy in the template.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->
1. Install and activate the Playground plugin
2. Go to `/wp-admin/tools.php?page=playground`
3. See the top toolbar.
