### PR TITLE
WP-NOW: Use SSH URL for release-wp-now.yml

### DIFF
--- a/.github/workflows/release-wp-now.yml
+++ b/.github/workflows/release-wp-now.yml
@@ -36,7 +36,7 @@ jobs:
               run: |
                   git config --global user.name "deployment_bot"
                   git config --global user.email "deployment_bot@users.noreply.github.com"
-                  git remote set-url origin https://${{ secrets.GH_ACTOR }}:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}
+                  git remote set-url origin git@github.com:WordPress/playground-tools.git
             - name: Authenticate with Registry
               run: |
                   echo "@wp-now:registry=https://registry.npmjs.org/" >> ~/.npmrc


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

- Related to:
  - https://github.com/WordPress/playground-tools/pull/227
  - https://github.com/WordPress/playground-tools/pull/190

## What?

Try using the URL in SSH format.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

`wp-now` workflow not working

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->
* Hard to test until it's merged and the action works.