### PR TITLE
WP-NOW: Add examples using rewrite-wp-config and WP_DEBUG on Readme.

### DIFF
--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -128,7 +128,7 @@ Blueprints are JSON files with a list of steps to execute after starting wp-now.
 
 Here is an example of a Blueprint that defines custom URL constant. `wp-now` will automatically detect the blueprint and execute it after starting the server. In consequence, the site will be available at `http://myurl.wpnow`. Make sure myurl.wpnow is added to your hosts file.
 
-To execute this Blueprint, create a file named `blueprint-example.json` and run `wp-now start --blueprint=path/to/blueprint-example.json`. Note that the `virtualize` is set to `true` to avoid modifying the `wp-config.php` file that is shared between all the projects.
+To execute this Blueprint, create a file named `blueprint-example.json` and run `wp-now start --blueprint=path/to/blueprint-example.json`. Note that the `method` is set to `define-before-run` to avoid modifying the `wp-config.php` file that is shared between all the projects. In contrast, the method `rewrite-wp-config` will modify the `wp-config.php` in disk.
 
 ```json
 {
@@ -179,18 +179,17 @@ Run `wp-now start --blueprint=path/to/blueprint-example.json` where `blueprint-e
 		{
 			"step": "defineWpConfigConsts",
 			"consts": {
-				"WP_DEBUG": true,
-				"WP_DEBUG_LOG": true
-			},
-			"method": "define-before-run"
+				"WP_DEBUG": true
+			}
 		}
 	]
 }
 ```
 
-This will enable the debug logs and will create a `debug.log` file in the `~/.wp-now/wp-content/${project}/debug.log` directory.
+Because we didn't define a method for `defineWpConfigConsts`, and the default method is `rewrite-wp-config`, this blueprint will update your `~/.wp-now/wordpress-versions/latest/wp-config.php` enabling the WP_DEBUG constant and will create a `debug.log` file in the `~/.wp-now/wp-content/${project}/debug.log` directory.
+The next time you execute `wp-now start` in any project, the variable `WP_DEBUG` will still be set to true.
 
-If you prefer to set a custom path for the debug log file, you can set `WP_DEBUG_LOG` to be a directory. Remember that the `php-wasm` server runs udner a VFS (virtual file system) where the default documentRoot is always `/var/www/html`.
+If you prefer to set a custom path for the debug log file, you can set `WP_DEBUG_LOG` to be a directory. Remember that the `php-wasm` server runs udner a VFS (virtual file system) where the default documentRoot for wp-now is always `/var/www/html`.
 
 For example, if you run `wp-now start --blueprint=path/to/blueprint-example.json` from a theme named `atlas` you could use this directory: `/var/www/html/wp-content/themes/atlas/example.log` and you will find the `example.log` file in your project directory.
 
@@ -200,6 +199,7 @@ For example, if you run `wp-now start --blueprint=path/to/blueprint-example.json
 		{
 			"step": "defineWpConfigConsts",
 			"consts": {
+				"WP_DEBUG": true,
 				"WP_DEBUG_LOG": "/var/www/html/wp-content/themes/atlas/example.log"
 			},
 			"method": "define-before-run"

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -189,7 +189,7 @@ Run `wp-now start --blueprint=path/to/blueprint-example.json` where `blueprint-e
 Because we didn't define a method for `defineWpConfigConsts`, and the default method is `rewrite-wp-config`, this blueprint will update your `~/.wp-now/wordpress-versions/latest/wp-config.php` enabling the WP_DEBUG constant and will create a `debug.log` file in the `~/.wp-now/wp-content/${project}/debug.log` directory.
 The next time you execute `wp-now start` in any project, the variable `WP_DEBUG` will still be set to true.
 
-If you prefer to set a custom path for the debug log file, you can set `WP_DEBUG_LOG` to be a directory. Remember that the `php-wasm` server runs udner a VFS (virtual file system) where the default documentRoot for wp-now is always `/var/www/html`.
+If you prefer to set a custom path for the debug log file, you can set `WP_DEBUG_LOG` to be a directory. Remember that the `php-wasm` server runs under a VFS (virtual file system) where the default documentRoot for wp-now is always `/var/www/html`.
 
 For example, if you run `wp-now start --blueprint=path/to/blueprint-example.json` from a theme named `atlas` you could use this directory: `/var/www/html/wp-content/themes/atlas/example.log` and you will find the `example.log` file in your project directory.
 


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->

Update the WP_DEBUG example to use the method `rewrite-wp-config` which avoids conflicting with other constants but it modifies the wp-config.php file shared across projects.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The current example works, but it displays warning in the Frontend:



## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->

* Read the readme https://github.com/WordPress/playground-tools/blob/update/wp-now-readme-rewrite-wp-config/packages/wp-now/README.md#using-blueprints