### PR TITLE
WP-NOW: Open browser with blueprint landingPage instead of absoluteUrl

### DIFF
--- a/packages/wp-now/src/config.ts
+++ b/packages/wp-now/src/config.ts
@@ -45,6 +45,7 @@ export interface WPNowOptions {
 	numberOfPhpInstances?: number;
 	blueprintObject?: Blueprint;
 	reset?: boolean;
+	landingPage?: string;
 }
 
 export const DEFAULT_OPTIONS: WPNowOptions = {
@@ -55,6 +56,7 @@ export const DEFAULT_OPTIONS: WPNowOptions = {
 	mode: WPNowMode.AUTO,
 	numberOfPhpInstances: 1,
 	reset: false,
+	landingPage: '',
 };
 
 export interface WPEnvOptions {
@@ -166,6 +168,10 @@ export default async function getWpNowConfig(
 		if (siteUrl) {
 			options.absoluteUrl = siteUrl;
 			absoluteUrlFromBlueprint = siteUrl;
+		}
+		if (blueprintObject.landingPage) {
+			options.landingPage =
+				(await getAbsoluteURL()) + blueprintObject.landingPage;
 		}
 	}
 	return options;

--- a/packages/wp-now/src/start-server.ts
+++ b/packages/wp-now/src/start-server.ts
@@ -89,9 +89,9 @@ export async function startServer(
 			output?.trace(e);
 		}
 	});
-	const url = options.absoluteUrl;
+	const url = options.landingPage || options.absoluteUrl;
 	const server = app.listen(port, () => {
-		output?.log(`Server running at ${url}`);
+		output?.log(`Server running at ${options.absoluteUrl}`);
 	});
 
 	return {


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

- Related to: https://github.com/WordPress/playground-tools/issues/265

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->

Open blueprint landingPage when defined instead of absoluteUrl.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It improves the UX of some use cases, for example https://github.com/adamziel/playground-docs-workflow/tree/trunk/wp-content

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

It adds a new property to WpNowOptions object

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->

- Run `npx nx run wp-now:build`
- Create a blueprint with a landing page:
```
{
	"landingPage": "/wp-admin/edit.php?post_type=post",
	"features": {
		"networking": true
	},
	"steps": [
		{
			"step": "login",
			"username": "admin",
			"password": "password"
		}
	]
}
```
- Run `node dist/packages/wp-now/cli.js start --blueprint=b.json`
- Observe the browser opens the landingPage in wp-admin instead of the homepage.

https://github.com/WordPress/playground-tools/assets/779993/4af27d25-c3d8-458a-b587-24809c88bf0e


cc: @flexseth