### PR TITLE
Playground Block: set style version number

### DIFF
--- a/packages/wordpress-playground-block/src/block.json
+++ b/packages/wordpress-playground-block/src/block.json
@@ -2,7 +2,6 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "wordpress-playground/playground",
-	"version": "0.0.1",
 	"title": "WordPress Playground",
 	"category": "widgets",
 	"icon": "wordpress",

--- a/packages/wordpress-playground-block/wordpress-playground-block.php
+++ b/packages/wordpress-playground-block/wordpress-playground-block.php
@@ -15,7 +15,23 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-function playground_demo_block_init() {
-	register_block_type( __DIR__ . '/build' );
+function playground_demo_block_init()
+{
+	$style_css = 'build/style-index.css';
+	wp_register_style(
+		'playground-block-style',
+		plugins_url($style_css, __FILE__),
+		array(
+			'wp-components'
+		),
+		filemtime(plugin_dir_path(__FILE__) . $style_css),
+	);
+
+	register_block_type(
+		__DIR__ . '/build',
+		array(
+			'style' => 'playground-block-style',
+		)
+	);
 }
 add_action( 'init', 'playground_demo_block_init' );


### PR DESCRIPTION
Fixes #254

<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

This PR ensures that the style cache will be busted when a new version is released. 

## Why?

The style version is currently displayed as _0.0.1_ which matches `block.json`. 
When a new version of the plugin is released, browsers keep returning the cached version of the style file which might be outdate.

## How?

The style file is now manually registered and a version is set to the last modified time of the file. This will ensure that if a new version is installed, browsers will flush the cache.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
1. Check out the branch.
2. Start a local dev site
3. Open a post edit page and add a playground block
4. In network tools confirm that the style path has a timestamp as a version (e.g. _build/style-index.css?ver=1715165957_)
