### PR TITLE
Playground Block: Move live preview toggle to general panel

### DIFF
--- a/packages/wordpress-playground-block/src/edit.tsx
+++ b/packages/wordpress-playground-block/src/edit.tsx
@@ -59,6 +59,23 @@ export default function Edit({
 			/>
 			<InspectorControls>
 				<Panel header="Settings">
+					<PanelBody title="General" initialOpen={true}>
+						<ToggleControl
+							label="Require live preview activation"
+							help={
+								requireLivePreviewActivation
+									? 'User must click to load the preview.'
+									: 'Preview begins loading immediately.'
+							}
+							checked={requireLivePreviewActivation}
+							onChange={() => {
+								setAttributes({
+									requireLivePreviewActivation:
+										!requireLivePreviewActivation,
+								});
+							}}
+						/>
+					</PanelBody>
 					<PanelBody title="Code editor" initialOpen={true}>
 						<ToggleControl
 							label="Code editor"
@@ -118,21 +135,6 @@ export default function Edit({
 										setAttributes({
 											codeEditorMultipleFiles:
 												!codeEditorMultipleFiles,
-										});
-									}}
-								/>
-								<ToggleControl
-									label="Require live preview activation"
-									help={
-										requireLivePreviewActivation
-											? 'User must click to load the preview.'
-											: 'Preview begins loading immediately.'
-									}
-									checked={requireLivePreviewActivation}
-									onChange={() => {
-										setAttributes({
-											requireLivePreviewActivation:
-												!requireLivePreviewActivation,
 										});
 									}}
 								/>


### PR DESCRIPTION
Fixes #255 

<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

Moves live preview toggle to a new General panel to make easily discoverable. 

## Why?

The live preview toggle is hidden in the Code editor panel and only accessible if the code editor is enabled.

## How?

By creating a new panel and moving the toggle to it.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
1. Check out the branch.
2. Start editing a post and add a new Playground block
3. In Block settings confirm that there is a new Greneral tab and that it has a _Require live preview activation_ toggle

![image](https://github.com/WordPress/playground-tools/assets/1199991/fc366115-fa8d-461b-bc34-2461cd177179)

