### PR TITLE
Playground block: Base64 encode attributes to prevent KSES from breaking the values on save

### DIFF
--- a/packages/playground/assets/js/playground.js
+++ b/packages/playground/assets/js/playground.js
@@ -1,6 +1,8 @@
 (async () => {
 	const onError = (error) => {
-		alert(`Playground couldn’t start. Please check the browser console for more information. ${error}`);
+		alert(
+			`Playground couldn’t start. Please check the browser console for more information. ${error}`
+		);
 		const backButton = document.getElementById('goBack');
 		if (backButton) {
 			backButton.click();

--- a/packages/wordpress-playground-block/src/base64.ts
+++ b/packages/wordpress-playground-block/src/base64.ts
@@ -1,0 +1,95 @@
+/**
+ * Base64 encoding and decoding functions.
+ * We cannot just use `btoa` and `atob` because they do not
+ * support Unicode characters.
+ */
+
+const attributesToBase64 = [
+	'blueprint',
+	'blueprintUrl',
+	'codeEditorErrorLog',
+	'constants',
+	'files',
+];
+
+export function base64EncodeBlockAttributes(
+	blockAttributes: Record<string, any>
+) {
+	const base64Props: Record<string, string> = {};
+	for (const key in blockAttributes) {
+		if (
+			!attributesToBase64.includes(key) ||
+			typeof blockAttributes[key] === 'number' ||
+			typeof blockAttributes[key] === 'boolean' ||
+			typeof blockAttributes[key] === null ||
+			typeof blockAttributes[key] === undefined
+		) {
+			base64Props[key] = blockAttributes[key];
+			continue;
+		}
+		try {
+			base64Props[key] = stringToBase64(
+				JSON.stringify(blockAttributes[key])
+			);
+		} catch (error) {
+			base64Props[key] = blockAttributes[key] as string;
+		}
+	}
+	return base64Props;
+}
+
+export function base64DecodeBlockAttributes(
+	base64Attributes: Record<string, any>
+) {
+	const attributes: Record<string, any> = {};
+	// This is called in useMemo() on many re-renders,
+	// let's never throw, bale out early if we can't decode,
+	// and always return a valid object.
+	for (const key in base64Attributes) {
+		if (
+			!attributesToBase64.includes(key) ||
+			!(typeof base64Attributes[key] === 'string')
+		) {
+			attributes[key] = base64Attributes[key];
+			continue;
+		}
+		if (key in base64Attributes) {
+			try {
+				attributes[key] = JSON.parse(
+					base64ToString(base64Attributes[key])
+				);
+			} catch (error) {
+				// Ignore errors and keep the base64 encoded string.
+				attributes[key] = base64Attributes[key];
+			}
+		}
+	}
+	return attributes;
+}
+
+export function stringToBase64(string: string) {
+	return uint8ArrayToBase64(new TextEncoder().encode(string));
+}
+
+export function base64ToString(base64: string) {
+	return new TextDecoder().decode(base64ToUint8Array(base64));
+}
+
+export function uint8ArrayToBase64(bytes: Uint8Array) {
+	const binary = [];
+	const len = bytes.byteLength;
+	for (let i = 0; i < len; i++) {
+		binary.push(String.fromCharCode(bytes[i]));
+	}
+	return window.btoa(binary.join(''));
+}
+
+export function base64ToUint8Array(base64: string) {
+	const binaryString = window.atob(base64); // This will convert base64 to binary string
+	const len = binaryString.length;
+	const bytes = new Uint8Array(len);
+	for (let i = 0; i < len; i++) {
+		bytes[i] = binaryString.charCodeAt(i);
+	}
+	return bytes;
+}

--- a/packages/wordpress-playground-block/src/base64.ts
+++ b/packages/wordpress-playground-block/src/base64.ts
@@ -27,13 +27,9 @@ export function base64EncodeBlockAttributes(
 			base64Props[key] = blockAttributes[key];
 			continue;
 		}
-		try {
-			base64Props[key] = stringToBase64(
-				JSON.stringify(blockAttributes[key])
-			);
-		} catch (error) {
-			base64Props[key] = blockAttributes[key] as string;
-		}
+		base64Props[key] = stringToBase64(
+			JSON.stringify(blockAttributes[key])
+		);
 	}
 	// The "files" attribute is of type array
 	if ('files' in base64Props) {

--- a/packages/wordpress-playground-block/src/base64.ts
+++ b/packages/wordpress-playground-block/src/base64.ts
@@ -42,13 +42,21 @@ export function base64EncodeBlockAttributes(
 	return base64Props;
 }
 
+/**
+ * Turns base64 encoded attributes back into their original form.
+ * It never throws, bales out early if we can't decode, and always
+ * returns a valid object. If any attribute cannot be decoded, it
+ * will be kept in its original form and presumed to have a non-base64
+ * value to keep the older version of the block working without
+ * migrating the attributes.
+ *
+ * @param base64Attributes
+ * @returns
+ */
 export function base64DecodeBlockAttributes(
 	base64Attributes: Record<string, any>
 ) {
 	const attributes: Record<string, any> = {};
-	// This is called in useMemo() on many re-renders,
-	// let's never throw, bale out early if we can't decode,
-	// and always return a valid object.
 	for (const key in base64Attributes) {
 		let valueToDecode = base64Attributes[key];
 		// The "files" attribute is of type array

--- a/packages/wordpress-playground-block/src/base64.ts
+++ b/packages/wordpress-playground-block/src/base64.ts
@@ -4,7 +4,7 @@
  * support Unicode characters.
  */
 
-const attributesToBase64 = [
+export const attributesToBase64 = [
 	'blueprint',
 	'blueprintUrl',
 	'codeEditorErrorLog',
@@ -35,6 +35,10 @@ export function base64EncodeBlockAttributes(
 			base64Props[key] = blockAttributes[key] as string;
 		}
 	}
+	// The "files" attribute is of type array
+	if ('files' in base64Props) {
+		base64Props['files'] = [base64Props['files']] as any;
+	}
 	return base64Props;
 }
 
@@ -46,18 +50,21 @@ export function base64DecodeBlockAttributes(
 	// let's never throw, bale out early if we can't decode,
 	// and always return a valid object.
 	for (const key in base64Attributes) {
+		let valueToDecode = base64Attributes[key];
+		// The "files" attribute is of type array
+		if (key === 'files') {
+			valueToDecode = valueToDecode[0];
+		}
 		if (
 			!attributesToBase64.includes(key) ||
-			!(typeof base64Attributes[key] === 'string')
+			!(typeof valueToDecode === 'string')
 		) {
 			attributes[key] = base64Attributes[key];
 			continue;
 		}
 		if (key in base64Attributes) {
 			try {
-				attributes[key] = JSON.parse(
-					base64ToString(base64Attributes[key])
-				);
+				attributes[key] = JSON.parse(base64ToString(valueToDecode));
 			} catch (error) {
 				// Ignore errors and keep the base64 encoded string.
 				attributes[key] = base64Attributes[key];

--- a/packages/wordpress-playground-block/src/edit.tsx
+++ b/packages/wordpress-playground-block/src/edit.tsx
@@ -62,7 +62,7 @@ function withBase64Attrs(Component: any) {
 		 * calling setAttributes() on each change. Then, debounce the actual
 		 * setAttributes() call to prevent encoding/decoding/re-render on each
 		 * key stroke.
-		 * 
+		 *
 		 * Other attributes are just passed to props.setAttributes().
 		 */
 		function setAttributes(attributes: any) {

--- a/packages/wordpress-playground-block/src/edit.tsx
+++ b/packages/wordpress-playground-block/src/edit.tsx
@@ -87,7 +87,7 @@ function withBase64Attrs(Component: any) {
 				setBase64Attributes(newBase64Attributes);
 			}
 
-			// Debounce the encoding in 500ms to prevent encoding/decoding/re-render on
+			// Debounce the encoding to prevent encoding/decoding/re-render on
 			// each key stroke.
 			if (ref.current.encodeTimeout) {
 				clearTimeout(ref.current.encodeTimeout);
@@ -98,7 +98,7 @@ function withBase64Attrs(Component: any) {
 				);
 				clearTimeout(ref.current.encodeTimeout);
 				ref.current.encodeTimeout = null;
-			}, 500);
+			}, 100);
 		}
 
 		return (

--- a/packages/wordpress-playground-block/src/view.tsx
+++ b/packages/wordpress-playground-block/src/view.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createRoot } from '@wordpress/element';
 import PlaygroundPreview from './components/playground-preview';
+import { base64DecodeBlockAttributes } from './base64';
 
 function renderPlaygroundPreview() {
 	const playgroundDemo = Array.from(
@@ -10,9 +11,9 @@ function renderPlaygroundPreview() {
 	for (const element of playgroundDemo) {
 		const rootElement = element as HTMLDivElement;
 		const root = createRoot(rootElement);
-		const attributes = JSON.parse(
-			atob(rootElement.dataset['attributes'] || '')
-		);
+		const attributes = base64DecodeBlockAttributes(
+			JSON.parse(atob(rootElement.dataset['attributes'] || ''))
+		) as any;
 
 		root.render(<PlaygroundPreview {...attributes} />);
 	}


### PR DESCRIPTION
Some WordPress installations are overly eager with their HTML entity encoding and will save, e.g., `<?php` as `&lt;php`. We cannot easily detect this to decode these HTML entities only when needed, so let's just store the attributes using base64 encoding to prevent WordPress from breaking them.

This PR encodes the most entity-encoding-susceptible attributes to base64 in the block editor. To avoid an expensive encode/decode operation on each key stroke, the base64 encode operation is debounced.

 ## Testing instructions

* Install the trunk version of this block on a site
* Insert it on a page with a code editor, a few files, and a Blueprint
* Switch to this branch
* Confirm the original block still works in the editor and on the frontend
* Update any attribute, save it, refresh the page
* Confirm it still works in the editor and on the frontend
* Insert a new block, insert a few files in the code editor, update the Blueprint attribute, save it
* Confirm it works in the editor and on the frontend
