### PR TITLE
Fix PHP 7.2.x Syntax Error Causing Site-wide Fatal Server Error (Trailing Comma in the Parameters of a Function)

### DIFF
--- a/packages/wordpress-playground-block/wordpress-playground-block.php
+++ b/packages/wordpress-playground-block/wordpress-playground-block.php
@@ -24,7 +24,7 @@ function playground_demo_block_init()
 		array(
 			'wp-components'
 		),
-		filemtime(plugin_dir_path(__FILE__) . $style_css),
+		filemtime(plugin_dir_path(__FILE__) . $style_css)
 	);
 
 	register_block_type(


### PR DESCRIPTION
## What?

The plugin claims PHP 7.0+ support, but the trailing comma in the parameters when calling `wp_register_style` is a syntax error for PHP 7.2.x (and possibly others) which then causes a site-wide fatal server error when the plugin is enabled.

The exact error message is:
> **PHP Parse error:**  syntax error, unexpected `)` in `/wp-content/plugins/interactive-code-block/wordpress-playground-block.php` on `line 28`

## Why?

This either needs to not try to and/or claim support of PHP 7.2 & older, or (per this pull request) make this one fix & just be mindful to not have these trailing commas in future updates and/or have the plugin files be checked for this type of thing via CI before releasing a new version (these trailing commas don't do anything anyway & just cause it to potentially break on some hosting environments; unlike the trailing commas in PHP arrays, etc. for whatever reason.)

## How?

This simply removes the comma at the end of `wp_register_style`'s parameters which isn't doing anything other than breaking things for those with PHP 7.2.x.

## Testing Instructions

1. Have a site with this plugin on PHP 7.2.x where it causes the entire site to give a fatal server error before the fix.
2. Implement this quick fix of just removing that one comma
3. Find the site's back to working as expected.