### PR TITLE
WP-NOW: add plugin update tests

### DIFF
--- a/packages/wp-now/src/tests/download-with-timer.ts
+++ b/packages/wp-now/src/tests/download-with-timer.ts
@@ -1,0 +1,7 @@
+export async function downloadWithTimer(name, fn) {
+	console.log(`Downloading ${name}...`);
+	console.time(name);
+	await fn();
+	console.log(`${name} downloaded.`);
+	console.timeEnd(name);
+}

--- a/packages/wp-now/src/tests/update-plugin-updates.spec.ts
+++ b/packages/wp-now/src/tests/update-plugin-updates.spec.ts
@@ -1,0 +1,141 @@
+import startWPNow from '../wp-now';
+import { getWpNowPath } from '../';
+import getWpNowConfig, { CliOptions } from '../config';
+import fs from 'fs-extra';
+import path from 'path';
+import {
+	downloadSqliteIntegrationPlugin,
+	downloadWordPress,
+} from '../download';
+import os from 'os';
+import crypto from 'crypto';
+import { downloadWithTimer } from './download-with-timer';
+import getWpNowTmpPath from '../get-wp-now-tmp-path';
+
+const exampleDir = __dirname + '/mode-examples';
+
+async function copyWordPressAndStart(tmpDirectory: string, folderName: string) {
+	// Copy whole WordPress directory to a temporary directory
+	const wordPressDir = path.join(
+		getWpNowPath(),
+		'wordpress-versions',
+		'latest'
+	);
+	const projectPath = path.join(tmpDirectory, folderName);
+	fs.copySync(wordPressDir, projectPath);
+
+	const options = await getWpNowConfig({ path: projectPath });
+	return await startWPNow(options);
+}
+
+describe('Test WordPress plugin updates', () => {
+	let tmpExampleDirectory;
+
+	/**
+	 * Download an initial copy of WordPress
+	 */
+	beforeAll(async () => {
+		await Promise.all([
+			downloadWithTimer('wordpress', downloadWordPress),
+			downloadWithTimer('sqlite', downloadSqliteIntegrationPlugin),
+		]);
+	});
+
+	/**
+	 * Copy example directory to a temporary directory
+	 */
+	beforeEach(() => {
+		const tmpDirectory = os.tmpdir();
+		const directoryHash = crypto.randomBytes(20).toString('hex');
+
+		tmpExampleDirectory = path.join(
+			tmpDirectory,
+			`wp-now-tests-examples-${directoryHash}`
+		);
+		fs.ensureDirSync(tmpExampleDirectory);
+		fs.copySync(exampleDir, tmpExampleDirectory);
+	});
+
+	/**
+	 * Remove temporary directory
+	 */
+	afterEach(() => {
+		fs.rmSync(tmpExampleDirectory, { recursive: true, force: true });
+	});
+
+	/**
+	 * Remove wp-now hidden directory from temporary directory.
+	 */
+	afterAll(() => {
+		fs.rmSync(getWpNowTmpPath(), { recursive: true, force: true });
+	});
+
+	test('move a directory', async () => {
+		const { php } = await copyWordPressAndStart(
+			tmpExampleDirectory,
+			'wordpress-move-directory'
+		);
+		const code = `<?php
+			require_once 'wp-load.php';
+			require_once 'wp-admin/includes/file.php';
+
+			WP_Filesystem();
+			global $wp_filesystem;
+
+			$path = 'wp-content/plugins/akismet';
+
+			echo "Path: " . $path . "\n";
+
+			$result = $wp_filesystem->exists($path);
+			echo "exists before " . ($result ? 'true' : 'false') . "\n";
+
+			$result = move_dir($path, "./wp-content/other-path", true);
+			echo "moved " . ($result ? 'true' : 'false') . "\n";
+
+			$result = $wp_filesystem->exists($path);
+			echo "exists after " . ($result ? 'true' : 'false') . "\n";
+		?>`;
+		const result = await php.run({
+			code,
+		});
+
+		expect(result.text).toMatch('Path: wp-content/plugins/akismet');
+		expect(result.text).toMatch('exists before true');
+		expect(result.text).toMatch('exists after false');
+	});
+
+	test('delete a directory', async () => {
+		const { php } = await copyWordPressAndStart(
+			tmpExampleDirectory,
+			'wordpress-move-directory'
+		);
+		const code = `<?php
+			require_once 'wp-load.php';
+			require_once 'wp-admin/includes/file.php';
+
+			WP_Filesystem();
+			global $wp_filesystem;
+
+			$path = 'wp-content/plugins/akismet';
+
+			echo "Path: " . $path . "\n";
+
+			$result = $wp_filesystem->exists($path);
+			echo "exists before " . ($result ? 'true' : 'false') . "\n";
+
+			$deleted = $wp_filesystem->delete( $path, true );
+			echo "deleted " . ($deleted ? 'true' : 'false') . "\n";
+
+			$result = $wp_filesystem->exists($path);
+			echo "exists after " . ($result ? 'true' : 'false') . "\n";
+		?>`;
+		const result = await php.run({
+			code,
+		});
+
+		expect(result.text).toMatch('Path: wp-content/plugins/akismet');
+		expect(result.text).toMatch('exists before true');
+		expect(result.text).toMatch('deleted true');
+		expect(result.text).toMatch('exists after false');
+	});
+});

--- a/packages/wp-now/src/tests/update-plugin-updates.spec.ts
+++ b/packages/wp-now/src/tests/update-plugin-updates.spec.ts
@@ -1,6 +1,6 @@
 import startWPNow from '../wp-now';
 import { getWpNowPath } from '../';
-import getWpNowConfig, { CliOptions } from '../config';
+import getWpNowConfig from '../config';
 import fs from 'fs-extra';
 import path from 'path';
 import {
@@ -94,7 +94,7 @@ describe('Test WordPress plugin updates', () => {
 
 			$result = $wp_filesystem->exists($path);
 			echo "exists after " . ($result ? 'true' : 'false') . "\n";
-		?>`;
+		`;
 		const result = await php.run({
 			code,
 		});
@@ -128,7 +128,7 @@ describe('Test WordPress plugin updates', () => {
 
 			$result = $wp_filesystem->exists($path);
 			echo "exists after " . ($result ? 'true' : 'false') . "\n";
-		?>`;
+		`;
 		const result = await php.run({
 			code,
 		});
@@ -137,5 +137,76 @@ describe('Test WordPress plugin updates', () => {
 		expect(result.text).toMatch('exists before true');
 		expect(result.text).toMatch('deleted true');
 		expect(result.text).toMatch('exists after false');
+	});
+
+	test('update plugin', async () => {
+		const { php, options: { projectPath } } = await copyWordPressAndStart( tmpExampleDirectory, 'wordpress-plugin-update');
+
+		const akismetExistsBeforeUpdate = fs.existsSync(
+			path.join(projectPath, 'wp-content/plugins/akismet/akismet.php')
+		);
+		expect(akismetExistsBeforeUpdate).toBe(true);
+
+		const code = `<?php
+				require_once 'wp-load.php';
+				require_once 'wp-admin/includes/misc.php';
+				require_once 'wp-admin/includes/plugin.php';
+				require_once 'wp-admin/includes/class-wp-upgrader.php';
+				require_once 'wp-admin/includes/file.php';
+
+				WP_Filesystem();
+				global $wp_filesystem;
+
+				$plugin = 'akismet/akismet.php';
+				$plugin_file_path = 'wp-content/plugins/akismet/akismet.php';
+
+				$result = $wp_filesystem->exists($plugin_file_path);
+				echo "exists before update " . ($result ? 'true' : 'false') . "\n";
+
+				// Replace the akismet/akismet.php to a lower version to force an update
+				$plugin_file_content = $wp_filesystem->get_contents($plugin_file_path);
+				$plugin_file_content = preg_replace('/Version: (d|.)+/', 'Version: 5.3.1', $plugin_file_content);
+				$wp_filesystem->put_contents($plugin_file_path, $plugin_file_content);
+
+				// print first 10 lines of plugin_file_content
+				echo "First 10 lines of plugin_file_content: \n";
+				echo implode("\n", array_slice(explode("\n", $plugin_file_content), 0, 10));
+
+				wp_update_plugins();
+
+				$upgrader = new Plugin_Upgrader();
+				$upgrader->upgrade( $plugin );
+
+				echo "\n";
+				$result = $wp_filesystem->exists($plugin_file_path);
+				echo "exists after update " . ($result ? 'true' : 'false') . "\n";
+			`;
+
+		const result = await php.run({
+			code,
+		});
+
+		/* Example response:
+			exists before update true
+			<div class="wrap"><h1></h1><p>Downloading update from <span class="code pre">https://downloads.wordpress.org/plugin/akismet.5.3.2.zip</span>&#8230;</p>
+			<p>Unpacking the update&#8230;</p>
+			<p>Installing the latest version&#8230;</p>
+			<p>Removing the old version of the plugin&#8230;</p>
+			<p>Could not remove the old plugin.</p>
+			<p>Plugin update failed.</p>
+			</div>
+			exists after update true
+		*/
+
+		const akismetExistsAfterUpdate = fs.existsSync(
+			path.join(projectPath, 'wp-content/plugins/akismet/akismet.php')
+		);
+		expect(akismetExistsAfterUpdate).toBe(true);
+
+		expect(result.text).toMatch('exists before update true');
+		expect(result.text).toMatch('Removing the old version of the plugin');
+		expect(result.text).not.toMatch('Could not remove the old plugin');
+		expect(result.text).not.toMatch('Plugin update failed');
+		expect(result.text).toMatch('exists after update true');
 	});
 });

--- a/packages/wp-now/src/tests/update-plugin-updates.spec.ts
+++ b/packages/wp-now/src/tests/update-plugin-updates.spec.ts
@@ -140,7 +140,13 @@ describe('Test WordPress plugin updates', () => {
 	});
 
 	test('update plugin', async () => {
-		const { php, options: { projectPath } } = await copyWordPressAndStart( tmpExampleDirectory, 'wordpress-plugin-update');
+		const {
+			php,
+			options: { projectPath },
+		} = await copyWordPressAndStart(
+			tmpExampleDirectory,
+			'wordpress-plugin-update'
+		);
 
 		const akismetExistsBeforeUpdate = fs.existsSync(
 			path.join(projectPath, 'wp-content/plugins/akismet/akismet.php')
@@ -167,10 +173,6 @@ describe('Test WordPress plugin updates', () => {
 				$plugin_file_content = $wp_filesystem->get_contents($plugin_file_path);
 				$plugin_file_content = preg_replace('/Version: (d|.)+/', 'Version: 5.3.1', $plugin_file_content);
 				$wp_filesystem->put_contents($plugin_file_path, $plugin_file_content);
-
-				// print first 10 lines of plugin_file_content
-				echo "First 10 lines of plugin_file_content: \n";
-				echo implode("\n", array_slice(explode("\n", $plugin_file_content), 0, 10));
 
 				wp_update_plugins();
 

--- a/packages/wp-now/src/tests/update-plugin-updates.spec.ts
+++ b/packages/wp-now/src/tests/update-plugin-updates.spec.ts
@@ -35,6 +35,7 @@ describe('Test WordPress plugin updates', () => {
 	 * Download an initial copy of WordPress
 	 */
 	beforeAll(async () => {
+		fs.rmSync(getWpNowTmpPath(), { recursive: true, force: true });
 		await Promise.all([
 			downloadWithTimer('wordpress', downloadWordPress),
 			downloadWithTimer('sqlite', downloadSqliteIntegrationPlugin),

--- a/packages/wp-now/src/tests/wp-now.spec.ts
+++ b/packages/wp-now/src/tests/wp-now.spec.ts
@@ -21,16 +21,9 @@ import getWpNowTmpPath from '../get-wp-now-tmp-path';
 import getWpCliTmpPath from '../get-wp-cli-tmp-path';
 import { executeWPCli } from '../execute-wp-cli';
 import { runCli } from '../run-cli';
+import { downloadWithTimer } from './download-with-timer';
 
 const exampleDir = __dirname + '/mode-examples';
-
-async function downloadWithTimer(name, fn) {
-	console.log(`Downloading ${name}...`);
-	console.time(name);
-	await fn();
-	console.log(`${name} downloaded.`);
-	console.timeEnd(name);
-}
 
 // Options
 test('getWpNowConfig with default options', async () => {

--- a/packages/wp-now/vite.config.ts
+++ b/packages/wp-now/vite.config.ts
@@ -25,6 +25,7 @@ export default defineConfig(() => {
 			},
 			environment: 'jsdom',
 			include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+			threads: false,
 		},
 	};
 });


### PR DESCRIPTION
- Related: https://github.com/WordPress/playground-tools/issues/178

> [!NOTE]
> We won't merge this PR until the plugin update error is fixed

<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

Add tests to validate the WordPress Plugin Update flow.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently that flow fails and after fixing the underlaying error, these tests will confirm it works.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

It uses WordPress functions to trigger a plugin update.

## Testing Instructions

Run:
- `nvm use`
- `npm install`
- `npx nx run wp-now:test`


## Manual testing 

This test introduces an automatic verification of the plugin update.

Here is a screencast of the manual testing where it fails:

https://github.com/WordPress/playground-tools/assets/779993/5eb2c2ab-29f4-4c72-a217-5535dda1be27

You can observe that after updating the plugin, the folder is "removed":
The filesystem returns that the folder and its files does not exist.
While php function `$wp_filesystem->exists` returns true for the folder and its files.