### PR TITLE
Block plugin version to 0.2.5

### DIFF
--- a/packages/wordpress-playground-block/README.plugindirectory.txt
+++ b/packages/wordpress-playground-block/README.plugindirectory.txt
@@ -3,7 +3,7 @@ Contributors: wordpressdotorg, dawidurbanski, zieladam
 Tags: code, interactive, playground, block
 Requires at least: 6.0
 Tested up to: 6.4
-Stable tag: 0.2.4
+Stable tag: 0.2.5
 Requires PHP: 7.0
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/packages/wordpress-playground-block/wordpress-playground-block.php
+++ b/packages/wordpress-playground-block/wordpress-playground-block.php
@@ -4,7 +4,7 @@
  * Description:       WordPress Playground as a Gutenberg block.
  * Requires at least: 6.1
  * Requires PHP:      7.0
- * Version:           0.2.4
+ * Version:           0.2.5
  * Author:            Dawid Urbański, Adam Zieliński
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

WordPress Playground Block version update

