### PR TITLE
WP-NOW: add argument to skip opening the browser

### DIFF
--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -112,6 +112,7 @@ wp-now php my-file.php
 -   `--wp=<version>`: the version of WordPress to use. This is optional and if not provided, it will use a default version. The default version is set to the [latest WordPress version](https://wordpress.org/download/releases/)(example usage: `--wp=5.8`)
 -   `--blueprint=<path>`: the path of a JSON file with the Blueprint steps (requires Node 20). This is optional, if provided will execute the defined Blueprints. See [Using Blueprints](#using-blueprints) for more details.
 -   `--reset`: create a fresh SQLite database and wp-content directory, for modes that support persistence.
+-   `--skip-browser`: skip opening the browser after starting the server.
 
 Of these, `wp-now php` currently supports the `--path=<path>` and `--php=<version>` arguments.
 

--- a/packages/wp-now/src/run-cli.ts
+++ b/packages/wp-now/src/run-cli.ts
@@ -76,6 +76,11 @@ export async function runCli() {
 						'Create a new project environment, destroying the old project environment.',
 					type: 'boolean',
 				});
+				yargs.option('skip-browser', {
+					describe: 'Do not launch the default browser',
+					type: 'boolean',
+					default: false,
+				});
 				yargs.option('inspect', {
 					describe: 'Use Node debugging client.',
 					type: 'number',
@@ -114,7 +119,9 @@ export async function runCli() {
 					});
 					portFinder.setPort(options.port as number);
 					const { url } = await startServer(options);
-					openInDefaultBrowser(url);
+					if (argv.skipBrowser !== true) {
+						openInDefaultBrowser(url);
+					}
 				} catch (error) {
 					output?.error(error);
 					spinner.fail(


### PR DESCRIPTION
- Closes https://github.com/WordPress/playground-tools/issues/248
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->

It adds a new flag `--skip-browser` to avoid opening the browser by default.

I'm open to feedback for other names. When using `--no-open` yargs returns errors. It seems the argument cannot start by `--no-`.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Multiple users asked for this feature.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->

- Run:
  - `nvm use && npm install && npx nx build wp-now`
  - `node dist/packages/wp-now/cli.js start --skip-browser`
- Observe wp-now starts correctly and it doesn't automatically open the browser.


## Screencast

https://github.com/WordPress/playground-tools/assets/779993/53f37882-2a1a-4981-a819-cac24433c77f