### PR TITLE
Playground block: Strengthen CSS for activate button positioning

### DIFF
--- a/packages/wordpress-playground-block/src/style.scss
+++ b/packages/wordpress-playground-block/src/style.scss
@@ -184,7 +184,9 @@
 	}
 
 	.wordpress-playground-activate-button {
-		margin: auto;
+		// Use !important to defend against this button being
+		// incorrectly positioned due to opinionated theme styles.
+		margin: auto !important;
 		font-size: 20px;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

This plugin strengthens the margin property of the Playground block's activate button.

## Why?

Today, when running with the p2020 theme on WordPress.com, another rule sets `margin-bottom: 0` on top of our `margin: auto` and causes the button to be positioned at the bottom of the preview pane.
![CleanShot 2024-05-21 at 17 40 51@2x](https://github.com/WordPress/playground-tools/assets/205419/ddc04dac-e02c-4551-9509-1708cb098c62)

After this change, the button renders in the context of the p2020 theme without issue:
![Screenshot 2024-05-21 at 10 39 23 PM](https://github.com/WordPress/playground-tools/assets/530877/1f63e304-6d96-471a-9806-4390ffe74ca8)

Fixes #272

## How?

This PR makes `margin: auto` `!important`. It's a shame to need to do this, but AFAIK, there is no scenario in which we want a theme to be able to override the position of the Activate button.

## Testing Instructions

Because this is in the context of a theme running on a private site, it cannot be tested here, but I have tested this change privately, which is how the screenshot was taken.