### PR TITLE
Playground Block: Support JSX source transpilation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
 				"compressible": "2.0.18",
 				"compression": "1.7.4",
 				"copy-webpack-plugin": "11.0.0",
+				"esbuild-wasm": "0.21.3",
 				"express": "4.19.2",
 				"express-fileupload": "1.4.0",
 				"file-saver": "^2.0.5",
@@ -23992,6 +23993,17 @@
 			"resolved": "https://registry.npmjs.org/esbuild-plugin-ignore/-/esbuild-plugin-ignore-1.1.1.tgz",
 			"integrity": "sha512-RVh45nlpiFiBJuw687Qh935VQvSzIA4rkBBytYYb5M3bTQcxokULQFQW6Sj0YHbFR6thNWmQYFkBghEQt5D3jg==",
 			"dev": true
+		},
+		"node_modules/esbuild-wasm": {
+			"version": "0.21.3",
+			"resolved": "https://registry.npmjs.org/esbuild-wasm/-/esbuild-wasm-0.21.3.tgz",
+			"integrity": "sha512-DMOV+eeVra0yVq3XIojfczdEQsz+RiFnpEj7lqs8Gux9mlTpN7yIbw0a4KzLspn0Uhw6UVEH3nUAidSqc/rcQg==",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/escalade": {
 			"version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"compressible": "2.0.18",
 		"compression": "1.7.4",
 		"copy-webpack-plugin": "11.0.0",
+		"esbuild-wasm": "0.21.3",
 		"express": "4.19.2",
 		"express-fileupload": "1.4.0",
 		"file-saver": "^2.0.5",

--- a/packages/wordpress-playground-block/src/block.json
+++ b/packages/wordpress-playground-block/src/block.json
@@ -34,6 +34,10 @@
 			"type": "boolean",
 			"default": true
 		},
+		"codeEditorTranspileJsx": {
+			"type": "boolean",
+			"default": false
+		},
 		"codeEditorMode": {
 			"type": "string",
 			"default": "plugin"

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -29,6 +29,7 @@ import { LanguageSupport } from '@codemirror/language';
 import { writePluginFiles } from './write-plugin-files';
 import downloadZippedPlugin from './download-zipped-plugin';
 import classnames from 'classnames';
+import { transpilePluginFiles } from './transpile-plugin-files';
 
 export type PlaygroundDemoProps = Attributes & {
 	showAddNewFile: boolean;
@@ -75,7 +76,7 @@ export default function PlaygroundPreview({
 	codeEditor,
 	codeEditorSideBySide,
 	codeEditorReadOnly,
-	codeEditorMode,
+	codeEditorTranspileJsx,
 	constants,
 	logInUser,
 	createNewPost,
@@ -253,22 +254,15 @@ export default function PlaygroundPreview({
 	}
 
 	async function reinstallEditedPlugin() {
-		if (!playgroundClientRef.current) {
+		if (!playgroundClientRef.current || !codeEditor) {
 			return;
 		}
 
 		const client = playgroundClientRef.current;
-		if (codeEditorMode === 'editor-script') {
-			const docroot = await client.documentRoot;
-			await client.writeFile(
-				docroot + '/wp-content/mu-plugins/example-code.php',
-				"<?php add_action('admin_init',function(){wp_add_inline_script('wp-blocks','" +
-					activeFile.contents +
-					"','after');});"
-			);
-		} else if (codeEditorMode === 'plugin' && codeEditor) {
-			await writePluginFiles(client, files);
-		}
+		await writePluginFiles(
+			client,
+			codeEditorTranspileJsx ? await transpilePluginFiles(files) : files
+		);
 	}
 
 	const handleReRunCode = useCallback(() => {

--- a/packages/wordpress-playground-block/src/components/playground-preview/transpile-plugin-files.ts
+++ b/packages/wordpress-playground-block/src/components/playground-preview/transpile-plugin-files.ts
@@ -24,7 +24,7 @@ export const transpilePluginFiles = async (
 		esbuild = import('esbuild-wasm');
 		esbuildInitialized = (await esbuild)!.initialize({
 			worker: true,
-			wasmURL: 'https://unpkg.com/esbuild-wasm@0.21.3/esbuild.wasm',
+			wasmURL: new URL('./esbuild.wasm', (document as any).currentScript.src),
 		});
 	}
 

--- a/packages/wordpress-playground-block/src/components/playground-preview/transpile-plugin-files.ts
+++ b/packages/wordpress-playground-block/src/components/playground-preview/transpile-plugin-files.ts
@@ -9,9 +9,17 @@ let esbuildInitialized: any = undefined;
 
 const pluginNameRegex = /^(?:[ \t]*<\?php)?[ \t/*#@]*Plugin Name:(.*)$/im;
 
+export interface TranspilationFailure {
+	file: EditorFile;
+	error: Error;
+}
+
 export const transpilePluginFiles = async (
 	files: EditorFile[]
-): Promise<EditorFile[]> => {
+): Promise<{
+	transpiledFiles: EditorFile[];
+	failures: TranspilationFailure[];
+}> => {
 	if (esbuild === undefined) {
 		esbuild = import('esbuild-wasm');
 		esbuildInitialized = (await esbuild)!.initialize({
@@ -60,7 +68,7 @@ export const transpilePluginFiles = async (
 			];
 		}
 
-		// Don't transpile .js files
+		// Transpile .js files
 		if (file.name.endsWith('.js')) {
 			await esbuildInitialized;
 			try {
@@ -82,15 +90,33 @@ export const transpilePluginFiles = async (
 						contents: transpiled.code,
 					},
 				];
-			} catch {
-				// Default to an untranspiled file
-				return [file];
+			} catch (e) {
+				return [
+					{
+						file,
+						error: e,
+					} as TranspilationFailure,
+				];
 			}
 		}
+
 		return [file];
 	});
+
 	// Flatten the array
-	return (await Promise.all(transpiled)).flatMap((x) => x);
+	const results = (await Promise.all(transpiled)).flatMap((x) => x as any);
+
+	const transpiledFiles = results.filter(
+		(result: any): result is EditorFile => 'name' in result
+	);
+	const failures = results.filter(
+		(result): result is TranspilationFailure =>
+			(result as TranspilationFailure).error !== undefined
+	);
+	return {
+		transpiledFiles,
+		failures,
+	};
 };
 
 function preloadESMAndImportMapBlockJson(

--- a/packages/wordpress-playground-block/src/components/playground-preview/transpile-plugin-files.ts
+++ b/packages/wordpress-playground-block/src/components/playground-preview/transpile-plugin-files.ts
@@ -15,6 +15,14 @@ export const transpilePluginFiles = async (
 	}
 
 	const transpiled = files.map(async (file) => {
+		if (file.name === 'block.json') {
+			return [
+				{
+					name: 'block.json.esmodule.js',
+					contents: `export default ${file.contents}`,
+				},
+			];
+		}
 		// Don't transpile .js files
 		if (!file.name.endsWith('.js')) {
 			return file;

--- a/packages/wordpress-playground-block/src/components/playground-preview/transpile-plugin-files.ts
+++ b/packages/wordpress-playground-block/src/components/playground-preview/transpile-plugin-files.ts
@@ -1,0 +1,49 @@
+import type { EditorFile } from '../../index';
+
+let esbuild: Promise<typeof import('esbuild-wasm')> | undefined = undefined;
+let esbuildInitialized: any = undefined;
+
+export const transpilePluginFiles = async (
+	files: EditorFile[]
+): Promise<EditorFile[]> => {
+	if (esbuild === undefined) {
+		esbuild = import('esbuild-wasm');
+		esbuildInitialized = (await esbuild)!.initialize({
+			worker: true,
+			wasmURL: 'https://unpkg.com/esbuild-wasm@0.21.3/esbuild.wasm',
+		});
+	}
+
+	const transpiled = files.map(async (file) => {
+		// Don't transpile .js files
+		if (!file.name.endsWith('.js')) {
+			return file;
+		}
+		await esbuildInitialized;
+		try {
+			const transpiled = await (
+				await esbuild!
+			).transform(file.contents, {
+				loader: 'jsx',
+				target: 'esnext',
+				jsxFactory: 'wp.element.createElement',
+				format: 'esm',
+			});
+			return [
+				{
+					name: file.name + '.src',
+					contents: file.contents,
+				},
+				{
+					name: file.name,
+					contents: transpiled.code,
+				},
+			];
+		} catch {
+			// Default to an untranspiled file
+			return [file];
+		}
+	});
+	// Flatten the array
+	return (await Promise.all(transpiled)).flatMap((x) => x);
+};

--- a/packages/wordpress-playground-block/src/components/playground-preview/transpile-plugin-files.ts
+++ b/packages/wordpress-playground-block/src/components/playground-preview/transpile-plugin-files.ts
@@ -97,13 +97,13 @@ function preloadESMAndImportMapBlockJson(
 	phpContents: string,
 	files: EditorFile[]
 ) {
-	const blockJsonPaths = files
+	const jsonPaths = files
 		.map((file) => file.name)
-		.filter((name) => name.match(/(\/|^)block.json$/));
+		.filter((name) => name.endsWith('.json'));
 	const jsModulesRelativePaths = files
 		.map((file) => file.name)
 		.filter((name) => name.endsWith('.js'))
-		.concat(blockJsonPaths.map((name) => name + '.esmodule.js'));
+		.concat(jsonPaths.map((name) => name + '.esmodule.js'));
 
 	phpContents = phpContents.trim();
 	if (!phpContents.endsWith('?>')) {
@@ -135,14 +135,14 @@ SCRIPT;
 	// Remap ESM imports from block.json, that aren't widely supported,
 	// to imports from a JavaScript file, that are widely supported.
 	function playground_wp_esm_import_map($import_map) {
-		$block_json_paths = ${phpVar(blockJsonPaths)};
-		$block_json_mapping = array();
-		foreach($block_json_paths as $block_json_path) {
-			$block_json_path = plugins_url($block_json_path, __FILE__);
-			$block_js_path = plugins_url($block_json_path . '.esmodule.js', __FILE__);
-			$block_json_mapping[$block_json_path] = $block_js_path;
+		$json_paths = ${phpVar(jsonPaths)};
+		$json_mapping = array();
+		foreach($json_paths as $json_path) {
+			$json_path = plugins_url($json_path, __FILE__);
+			$js_path = plugins_url($json_path . '.esmodule.js', __FILE__);
+			$json_mapping[$json_path] = $js_path;
 		}
-		return array_merge($import_map, $block_json_mapping);
+		return array_merge($import_map, $json_mapping);
 	}
 	add_filter('wp_esm_import_map', 'playground_wp_esm_import_map');
 	`;

--- a/packages/wordpress-playground-block/src/edit.tsx
+++ b/packages/wordpress-playground-block/src/edit.tsx
@@ -122,6 +122,7 @@ export default withBase64Attrs(function Edit({
 	const {
 		codeEditor,
 		codeEditorReadOnly,
+		codeEditorTranspileJsx,
 		codeEditorSideBySide,
 		codeEditorMultipleFiles,
 		codeEditorMode,
@@ -216,6 +217,21 @@ export default withBase64Attrs(function Edit({
 										setAttributes({
 											codeEditorReadOnly:
 												!codeEditorReadOnly,
+										});
+									}}
+								/>
+								<ToggleControl
+									label="Transpile JSX to JS"
+									help={
+										`Transpiles JSX syntax to JS using esbuild. Only the JSX tags are ` +
+										`transpiled. Imports and other advanced ESM syntax features are ` +
+										`preserved.`
+									}
+									checked={codeEditorTranspileJsx}
+									onChange={() => {
+										setAttributes({
+											codeEditorTranspileJsx:
+												!codeEditorTranspileJsx,
 										});
 									}}
 								/>

--- a/packages/wordpress-playground-block/src/index.ts
+++ b/packages/wordpress-playground-block/src/index.ts
@@ -18,6 +18,7 @@ export type Attributes = {
 	codeEditor: boolean;
 	codeEditorReadOnly: boolean;
 	codeEditorSideBySide: boolean;
+	codeEditorTranspileJsx: boolean;
 	codeEditorMultipleFiles: boolean;
 	codeEditorMode: string;
 	logInUser: boolean;

--- a/packages/wordpress-playground-block/src/style.scss
+++ b/packages/wordpress-playground-block/src/style.scss
@@ -171,16 +171,53 @@
 		width: $playground-height;
 		max-width: 100%;
 		border: 0;
+		position: relative;
+	}
+
+	@mixin playground-pane-overlay {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+	}
+
+	.playground-container {
+		@include playground-pane;
 	}
 
 	.playground-iframe {
-		@include playground-pane;
+		width: 100%;
+		height: 100%;
 	}
 
 	.playground-activation-placeholder {
-		@include playground-pane;
+		@include playground-pane-overlay;
 		display: flex;
+		flex-direction: column;
 		background-color: #eee;
+	}
+
+	.playground-transpilation-failures {
+		@include playground-pane-overlay;
+
+		display: flex;
+		flex-direction: column;
+		padding: 20px;
+		background-color: rgba(39, 0, 0, 0.9) !important;
+		* {
+			color: white !important;
+		}
+		h3 {
+			font-size: 24px !important;
+		}
+		h1,h2,h3,h4,h5,h6,p {
+			margin-top: 10px !important;
+			margin-bottom: 10px !important;
+		}
+		p {
+			font-size: 15px !important;
+		}
 	}
 
 	.wordpress-playground-activate-button {

--- a/packages/wordpress-playground-block/webpack.config.js
+++ b/packages/wordpress-playground-block/webpack.config.js
@@ -18,7 +18,10 @@ module.exports = {
 	plugins: [
 		...defaultConfig.plugins,
 		new CopyWebpackPlugin({
-			patterns: [{ from: '*.php', to: '../' }],
+			patterns: [
+				{ from: '*.php', to: '../' },
+				{ from: '../../node_modules/esbuild-wasm/esbuild.wasm', to: './' },
+			],
 		}),
 	],
 };


### PR DESCRIPTION
Adds a "Transpile JSX" attribute to the Playground block that enables block-building examples using JSX syntax. This enables reusing existing JSX code examples in interactive tutorials on building WordPress blocks.

On the technical end, this PR uses `esbuild-wasm` to run the transpilation in the browser.

## Testing instructions

1. Insert the Playground block
2. Recreate this code example in the code editor: https://github.com/WordPress/gutenberg-examples/tree/trunk/blocks-jsx/01-basic-esnext
3. Apply the Blueprint below
4. Confirm the block displays a page with a "Hello world example" block

```json
{
  "landingPage": "/?page_id=1",
  "phpExtensionBundles": [
    "kitchen-sink"
  ],
  "preferredVersions": {
    "php": "7.4",
    "wp": "5.9"
  },
  "login": true,
  "steps": [
    {
      "step": "unzip",
      "extractToPath": "/tmp",
      "zipFile": {
        "resource": "url",
        "url": "https://github-proxy.com/proxy/?repo=wordpress/playground-tools&pr=133&directory=packages/wordpress-es-modules-plugin/src"
      }
    },
    {
      "step": "mv",
      "fromPath": "/tmp/packages/wordpress-es-modules-plugin/src",
      "toPath": "/wordpress/wp-content/plugins/esm"
    },
    {
      "step": "activatePlugin",
      "pluginPath": "esm/index.php"
    },
    {
      "step": "resetData"
    },
    {
      "step": "runPHP",
      "code": "<?php\nrequire '/wordpress/wp-load.php';\n$page_id = wp_insert_post( [\n\t'post_type'    => 'page',\n\t'post_status'  => 'publish',\n\t'post_title'   => 'Hello World example',\n\t'post_content' => '<!-- wp:gutenberg-examples/example-01-basic-esnext --><div style=\"background-color:#900;color:#fff;padding:20px\" class=\"wp-block-gutenberg-examples-example-01-basic-esnext\">Hello World, step 1 (from the frontend).</div><!-- /wp:gutenberg-examples/example-01-basic-esnext -->'\n] );\n"
    }
  ]
}
```
