### PR TITLE
Playground block: Prevent the CodeMirror keyboard shortcuts from leaking to the block editor

### DIFF
--- a/packages/interactive-code-block/src/lib/components/code-mirror/index.tsx
+++ b/packages/interactive-code-block/src/lib/components/code-mirror/index.tsx
@@ -51,11 +51,6 @@ export type CodeMirrorRef = {
 	getContents: () => string;
 };
 
-function stopPropagation(event: React.KeyboardEvent) {
-	event.preventDefault();
-	event.stopPropagation();
-}
-
 const CodeMirror: MemoExoticComponent<
 	ForwardRefExoticComponent<CodeMirrorProps & RefAttributes<CodeMirrorRef>>
 > = memo(
@@ -63,7 +58,7 @@ const CodeMirror: MemoExoticComponent<
 		{ onChange, onSave, initialContents, fileType, className = '' },
 		ref
 	) {
-		const codeMirrorRef = useRef<HTMLDivElement>(null);
+		const codeMirrorRef = useRef(null);
 		const contentsRef = useRef(initialContents);
 		const onChangeRef = useRef(onChange);
 		const languagePlugin = useLanguagePlugin(fileType);
@@ -155,40 +150,13 @@ const CodeMirror: MemoExoticComponent<
 		}, [languagePlugin, dep, codeMirrorRef.current]);
 
 		useEffect(() => {
+			// return a function to be executed at component unmount
 			return () => {
 				view && view.destroy();
 			};
 		}, [view]);
 
-		useEffect(() => {
-			function keyListener(event: KeyboardEvent) {
-				console.log('key listener');
-				// if (isFocused) {
-				// 	event.preventDefault();
-				// 	event.stopImmediatePropagation();
-				// }
-			}
-			const doc = codeMirrorRef.current!.ownerDocument;
-			console.log({ doc });
-			doc.addEventListener('keydown', keyListener, true);
-			doc.addEventListener('keyup', keyListener, true);
-			doc.addEventListener('keypress', keyListener, true);
-
-			return () => {
-				doc.removeEventListener('keydown', keyListener, true);
-				doc.removeEventListener('keyup', keyListener, true);
-				doc.removeEventListener('keypress', keyListener, true);
-			};
-		}, []);
-
-		return (
-			<div
-				ref={codeMirrorRef}
-				className={className}
-				onKeyDown={stopPropagation}
-				onKeyUp={stopPropagation}
-			/>
-		);
+		return <div ref={codeMirrorRef} className={className} />;
 	})
 );
 

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -110,6 +110,29 @@ export default function PlaygroundPreview({
 
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 	const playgroundClientRef = useRef<PlaygroundClient | null>(null);
+	const codeMirrorRef = useRef<any>(null);
+
+	/**
+	 * Prevent the CodeMirror keyboard shortcuts from leaking to the block editor.
+	 */
+	useEffect(() => {
+		if (!codeMirrorRef.current) return;
+
+		const view = codeMirrorRef.current.view;
+		if (!view) return;
+
+		function stopPropagation(event: KeyboardEvent) {
+			event.stopPropagation();
+		}
+		view.dom.addEventListener('keydown', stopPropagation);
+		view.dom.addEventListener('keypress', stopPropagation);
+		view.dom.addEventListener('keyup', stopPropagation);
+		return () => {
+			view.dom.removeEventListener('keydown', stopPropagation, true);
+			view.dom.removeEventListener('keyup', stopPropagation, true);
+			view.dom.removeEventListener('keypress', stopPropagation, true);
+		};
+	}, [codeMirrorRef.current]);
 
 	const [isLivePreviewActivated, setLivePreviewActivated] = useState(
 		!requireLivePreviewActivation
@@ -376,6 +399,7 @@ export default function PlaygroundPreview({
 						</div>
 						<div className="code-editor-wrapper">
 							<ReactCodeMirror
+								ref={codeMirrorRef}
 								value={activeFile.contents}
 								extensions={[
 									keymapExtension,


### PR DESCRIPTION
## What?

Prevents keyboard events from leaking from the code editor to the block editor. It solves the problem of, e.g., undoing block changes when pressing `cmd+z` with the intention of undoing code changes.

## Testing Instructions

1. Add a few paragraph blocks
2. Add the Playground block
3. Enable the code editor
4. Start typing
5. Press cmd+s, the code should be re-run
6. Press cmd+z a few times, it should only undo the changes inside the code editor but not in the block editor