### PR TITLE
Allow express app to be (optionally) passed to start-server

### DIFF
--- a/packages/wp-now/src/config.ts
+++ b/packages/wp-now/src/config.ts
@@ -13,6 +13,7 @@ import { isValidWordPressVersion } from './wp-playground-wordpress';
 import getWpNowPath from './get-wp-now-path';
 import { DEFAULT_PHP_VERSION, DEFAULT_WORDPRESS_VERSION } from './constants';
 import { isWebContainer, HostURL } from '@webcontainer/env';
+import express from 'express';
 
 export interface CliOptions {
 	php?: string;
@@ -47,6 +48,7 @@ export interface WPNowOptions {
 	blueprintObject?: Blueprint;
 	reset?: boolean;
 	landingPage?: string;
+	app?: express.Express
 }
 
 export const DEFAULT_OPTIONS: WPNowOptions = {

--- a/packages/wp-now/src/start-server.ts
+++ b/packages/wp-now/src/start-server.ts
@@ -43,7 +43,7 @@ export async function startServer(
 			`The given path "${options.projectPath}" does not exist.`
 		);
 	}
-	const app = express();
+	const app = options.app ? options.app : express();
 	app.use(compression({ filter: shouldCompress }));
 	app.use(addTrailingSlash('/wp-admin'));
 	const port = await portFinder.getOpenPort();


### PR DESCRIPTION

## What?

- Add optional `app` arg to `startServer` that is express app.

## Why?

I wanted to see if I could integrate this with an existing express app. I was able to make it work with one small change that I think is a useful change. Would allow using WordPress for part of a node application and or easily plug this package into existing application

This is what I am thinking:
```ts
import {
	getWpNowConfig,
	startServer
} from '@wp-now/wp-now';

const options = await getWpNowConfig({});
const app = express();
app.get('/api', (req, res) => {
	res.json({message:"Hi Roy"})
});
const {  url } = await startServer({...options,app});
console.log({url})
```
## How?

- Makes it optional arg
- Uses that app if needed

## Testing Instructions

### No Changes test
1. Check out the branch. 
2. `npx nx preview wp-now start`
3. Should work as-is, no changes.

### Works this way test
1. Check out the branch. 
2. Link `npm link @wp-now/wp-now` https://docs.npmjs.com/cli/v9/commands/npm-link
3. Make a new project
4. Install this wp-now locally
5. Test it with above example code

