### PR TITLE
update tested up to and minimum PHP

### DIFF
--- a/packages/playground/README.txt
+++ b/packages/playground/README.txt
@@ -2,9 +2,9 @@
 Contributors: wordpressdotorg, antoniosejas, berislavgrgicak, zieladam
 Tags: playground, staging, sandbox
 Requires at least: 6.0
-Tested up to: 6.4
+Tested up to: 6.6
 Stable tag: 0.1.7
-Requires PHP: 7.0
+Requires PHP: 7.4
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

Update the tested up to field in the Readme.txt 

## Why?
To avoid getting this warning "Warning: This plugin has not been tested with your current version of WordPress."

![Screenshot 2024-06-05 at 10 37 50](https://github.com/WordPress/playground-tools/assets/39980/3eadcd94-f289-415f-ad66-932ebc963fa0)


## How?

update the readme.txt 
Minium PHP changed to 7.4 because I was there, to align with WordPress Core
