### PR TITLE
Playground block: Stop monopolizing main element

### DIFF
--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -354,7 +354,10 @@ export default function PlaygroundPreview({
 
 	return (
 		<>
-			<section aria-label="Playground" className={mainContainerClass}>
+			<section
+				aria-label="WordPress Playground"
+				className={mainContainerClass}
+			>
 				{codeEditor && (
 					<div className="code-container">
 						<FileManagementModals

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -354,7 +354,7 @@ export default function PlaygroundPreview({
 
 	return (
 		<>
-			<main className={mainContainerClass}>
+			<section aria-label="Playground" className={mainContainerClass}>
 				{codeEditor && (
 					<div className="code-container">
 						<FileManagementModals
@@ -542,7 +542,7 @@ export default function PlaygroundPreview({
 						></iframe>
 					)}
 				</div>
-			</main>
+			</section>
 			<footer className="demo-footer">
 				<a
 					href="https://w.org/playground"


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

Fixes #292 - "Playground block: A11Y: Remove duplicate main landmarks"

This PR replaces the Playground block's `<main>` element with a `<section>` element annotated with an `aria-label`.

## Why?

There is only supposed to be one `<main>` element per document. We do not know if a document including a Playground block will be rendered within another `<main>` element, and there can be multiple Playground blocks in a single document.

## Testing Instructions

- `npx nx run wordpress-playground-block:dev`
- Create a new post
- Add a Playground block in the editor and confirm it renders normally
- Publish the post and confirm the Playground block renders normally on the front end
- Use screen reader and confirm that the section label is noted when engaging with the section
