### PR TITLE
Playground block: Add ARIA labels to icon-only buttons

### DIFF
--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -399,6 +399,7 @@ export default function PlaygroundPreview({
 							)}
 							{showAddNewFile && (
 								<Button
+									aria-label="Add File"
 									variant="secondary"
 									className="file-tab file-tab-extra"
 									onClick={() =>
@@ -411,6 +412,7 @@ export default function PlaygroundPreview({
 								</Button>
 							)}
 							<Button
+								aria-label="Download Code as a Zip file"
 								variant="secondary"
 								className="file-tab file-tab-extra"
 								onClick={() => {


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

This PR adds ARIA labels to the code editor's "Add File" and "Download Code as a Zip File" buttons which previously only included visual indications of their function.

Fixes #286

## Why?

Without ARIA labels, people using assistive technology may have no way to know what the buttons do.

## Testing Instructions

- `npx nx run wordpress-playground-block:dev`
- Create a new post
- Add a Playground block in the editor
- Use a screen reader to engage with the "Add File" and "Download Code as Zip File" button and confirm the labels are recognized
- Publish the post and use a screen reader to confirm the "Download Code as Zip File" button has a recognized label