### PR TITLE
Download exact WordPress version when passing an alias

### DIFF
--- a/packages/wp-now/src/tests/wp-now.spec.ts
+++ b/packages/wp-now/src/tests/wp-now.spec.ts
@@ -9,6 +9,7 @@ import {
 	isWpContentDirectory,
 	isWordPressDirectory,
 	isWordPressDevelopDirectory,
+	resolveWordPressVersion,
 } from '../wp-playground-wordpress';
 import {
 	downloadSqliteIntegrationPlugin,
@@ -202,8 +203,13 @@ describe('Test starting different modes', () => {
 	 */
 	beforeAll(async () => {
 		fs.rmSync(getWpNowTmpPath(), { recursive: true, force: true });
+		const { resolvedWordPressVersion } = await resolveWordPressVersion(
+			'latest'
+		);
 		await Promise.all([
-			downloadWithTimer('wordpress', downloadWordPress),
+			downloadWithTimer('wordpress', () =>
+				downloadWordPress(resolvedWordPressVersion)
+			),
 			downloadWithTimer('sqlite', downloadSqliteIntegrationPlugin),
 		]);
 	});

--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -26,6 +26,7 @@ import {
 	isWordPressDevelopDirectory,
 	getPluginFile,
 	readFileHead,
+	resolveWordPressVersion,
 } from './wp-playground-wordpress';
 import { output } from './output';
 import getWpNowPath from './get-wp-now-path';
@@ -75,12 +76,21 @@ export default async function startWPNow(
 		});
 		return { php, phpInstances, options };
 	}
-	if (options.wordPressVersion === 'trunk') {
-		options.wordPressVersion = 'nightly';
+
+	const { resolvedWordPressVersion, isDeveloperBuild } =
+		await resolveWordPressVersion(options.wordPressVersion);
+
+	let wpVersionOutput = resolvedWordPressVersion;
+
+	if (resolvedWordPressVersion !== options.wordPressVersion) {
+		const originalWordPressVersion = options.wordPressVersion;
+		options.wordPressVersion = resolvedWordPressVersion;
+		wpVersionOutput += ` (resolved from alias: ${originalWordPressVersion})`;
 	}
-	output?.log(`wp: ${options.wordPressVersion}`);
+
+	output?.log(`wp: ${wpVersionOutput}`);
 	await Promise.all([
-		downloadWordPress(options.wordPressVersion),
+		downloadWordPress(options.wordPressVersion, { isDeveloperBuild }),
 		downloadMuPlugins(),
 		downloadSqliteIntegrationPlugin(),
 	]);

--- a/packages/wp-now/src/wp-playground-wordpress/index.ts
+++ b/packages/wp-now/src/wp-playground-wordpress/index.ts
@@ -7,3 +7,4 @@ export * from './is-wordpress-directory';
 export * from './is-wordpress-develop-directory';
 export * from './get-plugin-file';
 export * from './read-file-head';
+export * from './resolve-wordpress-version';

--- a/packages/wp-now/src/wp-playground-wordpress/resolve-wordpress-version.ts
+++ b/packages/wp-now/src/wp-playground-wordpress/resolve-wordpress-version.ts
@@ -1,0 +1,39 @@
+function isVersionAlias(requestedWordPressVersion: string) {
+	return ['latest', 'trunk', 'nightly'].includes(requestedWordPressVersion);
+}
+
+const VERSION_CHECKER_ENDPOINT =
+	'https://api.wordpress.org/core/version-check/1.7';
+
+export async function resolveWordPressVersion(wordPressVersion: string) {
+	if (!isVersionAlias(wordPressVersion)) {
+		return {
+			resolvedWordPressVersion: wordPressVersion,
+			isDeveloperBuild: false,
+		};
+	}
+
+	const url = new URL(VERSION_CHECKER_ENDPOINT);
+
+	const isDeveloperBuild = wordPressVersion !== 'latest';
+
+	if (isDeveloperBuild) {
+		url.searchParams.set('channel', 'development');
+	}
+
+	const response = await fetch(url);
+	const data = await response.json();
+
+	const version = data?.offers?.[0]?.version ?? null;
+
+	if (version == null) {
+		throw new Error(
+			`Failed to fetch ${wordPressVersion} WordPress version`
+		);
+	}
+
+	return {
+		resolvedWordPressVersion: version as string,
+		isDeveloperBuild,
+	};
+}

--- a/packages/wp-now/src/wp-playground-wordpress/resolve-wordpress-version.ts
+++ b/packages/wp-now/src/wp-playground-wordpress/resolve-wordpress-version.ts
@@ -4,9 +4,9 @@ import getWpNowPath from '../get-wp-now-path';
 
 const VERSION_CHECKER_ENDPOINT =
 	'https://api.wordpress.org/core/version-check/1.7';
-const OFFLINE_FALLBACK_FILE = path.join(
+const OFFLINE_ALIAS_FILE = path.join(
 	getWpNowPath(),
-	'wp-version-offline.json'
+	'wp-version-offline-alias.json'
 );
 
 function isVersionAlias(requestedWordPressVersion: string): boolean {
@@ -27,29 +27,29 @@ async function fetchWordPressVersion(
 	return data?.offers?.[0]?.version ?? null;
 }
 
-async function readOfflineVersions(): Promise<Record<string, string>> {
+async function readOfflineAlias(): Promise<Record<string, string>> {
 	try {
-		return await fs.readJson(OFFLINE_FALLBACK_FILE);
+		return await fs.readJson(OFFLINE_ALIAS_FILE);
 	} catch (error) {
 		return {};
 	}
 }
 
-async function writeOfflineVersions(
+async function writeOfflineAlias(
 	offlineData: Record<string, string>
 ): Promise<void> {
 	try {
-		await fs.ensureFile(OFFLINE_FALLBACK_FILE);
-		await fs.writeJson(OFFLINE_FALLBACK_FILE, offlineData, { spaces: 2 });
+		await fs.ensureFile(OFFLINE_ALIAS_FILE);
+		await fs.writeJson(OFFLINE_ALIAS_FILE, offlineData, { spaces: 2 });
 	} catch (error) {
 		console.error('Failed to create offline fallback file:', error);
 	}
 }
 
-async function getOfflineVersion(
+async function getOfflineAlias(
 	wordPressVersion: string
 ): Promise<string | null> {
-	const offlineData = await readOfflineVersions();
+	const offlineData = await readOfflineAlias();
 	return offlineData[wordPressVersion] || null;
 }
 
@@ -67,9 +67,9 @@ export async function resolveWordPressVersion(wordPressVersion: string) {
 		const version = await fetchWordPressVersion(isDeveloperBuild);
 
 		if (version) {
-			const offlineData = await readOfflineVersions();
+			const offlineData = await readOfflineAlias();
 			offlineData[wordPressVersion] = version;
-			await writeOfflineVersions(offlineData);
+			await writeOfflineAlias(offlineData);
 
 			return {
 				resolvedWordPressVersion: version,
@@ -82,11 +82,11 @@ export async function resolveWordPressVersion(wordPressVersion: string) {
 		);
 	}
 
-	const offlineFallbackVersion = await getOfflineVersion(wordPressVersion);
+	const offlineAliasVersion = await getOfflineAlias(wordPressVersion);
 
-	if (offlineFallbackVersion) {
+	if (offlineAliasVersion) {
 		return {
-			resolvedWordPressVersion: offlineFallbackVersion,
+			resolvedWordPressVersion: offlineAliasVersion,
 			isDeveloperBuild,
 		};
 	}

--- a/packages/wp-now/src/wp-playground-wordpress/resolve-wordpress-version.ts
+++ b/packages/wp-now/src/wp-playground-wordpress/resolve-wordpress-version.ts
@@ -38,7 +38,12 @@ async function readOfflineVersions(): Promise<Record<string, string>> {
 async function writeOfflineVersions(
 	offlineData: Record<string, string>
 ): Promise<void> {
-	await fs.writeJson(OFFLINE_FALLBACK_FILE, offlineData, { spaces: 2 });
+	try {
+		await fs.ensureFile(OFFLINE_FALLBACK_FILE);
+		await fs.writeJson(OFFLINE_FALLBACK_FILE, offlineData, { spaces: 2 });
+	} catch (error) {
+		console.error('Failed to create offline fallback file:', error);
+	}
 }
 
 async function getOfflineVersion(

--- a/packages/wp-now/src/wp-playground-wordpress/resolve-wordpress-version.ts
+++ b/packages/wp-now/src/wp-playground-wordpress/resolve-wordpress-version.ts
@@ -91,7 +91,8 @@ export async function resolveWordPressVersion(wordPressVersion: string) {
 		};
 	}
 
-	throw new Error(
+	console.error(
 		`Failed to resolve ${wordPressVersion} WordPress version. Please check your internet connection or try again later.`
 	);
+	process.exit(1);
 }

--- a/packages/wp-now/src/wp-playground-wordpress/resolve-wordpress-version.ts
+++ b/packages/wp-now/src/wp-playground-wordpress/resolve-wordpress-version.ts
@@ -1,9 +1,52 @@
-function isVersionAlias(requestedWordPressVersion: string) {
-	return ['latest', 'trunk', 'nightly'].includes(requestedWordPressVersion);
-}
+import fs from 'fs-extra';
+import path from 'path';
+import getWpNowPath from '../get-wp-now-path';
 
 const VERSION_CHECKER_ENDPOINT =
 	'https://api.wordpress.org/core/version-check/1.7';
+const OFFLINE_FALLBACK_FILE = path.join(
+	getWpNowPath(),
+	'wp-version-offline.json'
+);
+
+function isVersionAlias(requestedWordPressVersion: string): boolean {
+	return ['latest', 'trunk', 'nightly'].includes(requestedWordPressVersion);
+}
+
+async function fetchWordPressVersion(
+	isDeveloperBuild: boolean
+): Promise<string | null> {
+	const url = new URL(VERSION_CHECKER_ENDPOINT);
+	if (isDeveloperBuild) {
+		url.searchParams.set('channel', 'development');
+	}
+
+	const response = await fetch(url);
+	const data = await response.json();
+
+	return data?.offers?.[0]?.version ?? null;
+}
+
+async function readOfflineVersions(): Promise<Record<string, string>> {
+	try {
+		return await fs.readJson(OFFLINE_FALLBACK_FILE);
+	} catch (error) {
+		return {};
+	}
+}
+
+async function writeOfflineVersions(
+	offlineData: Record<string, string>
+): Promise<void> {
+	await fs.writeJson(OFFLINE_FALLBACK_FILE, offlineData, { spaces: 2 });
+}
+
+async function getOfflineVersion(
+	wordPressVersion: string
+): Promise<string | null> {
+	const offlineData = await readOfflineVersions();
+	return offlineData[wordPressVersion] || null;
+}
 
 export async function resolveWordPressVersion(wordPressVersion: string) {
 	if (!isVersionAlias(wordPressVersion)) {
@@ -13,27 +56,37 @@ export async function resolveWordPressVersion(wordPressVersion: string) {
 		};
 	}
 
-	const url = new URL(VERSION_CHECKER_ENDPOINT);
-
 	const isDeveloperBuild = wordPressVersion !== 'latest';
 
-	if (isDeveloperBuild) {
-		url.searchParams.set('channel', 'development');
-	}
+	try {
+		const version = await fetchWordPressVersion(isDeveloperBuild);
 
-	const response = await fetch(url);
-	const data = await response.json();
+		if (version) {
+			const offlineData = await readOfflineVersions();
+			offlineData[wordPressVersion] = version;
+			await writeOfflineVersions(offlineData);
 
-	const version = data?.offers?.[0]?.version ?? null;
-
-	if (version == null) {
-		throw new Error(
-			`Failed to fetch ${wordPressVersion} WordPress version`
+			return {
+				resolvedWordPressVersion: version,
+				isDeveloperBuild,
+			};
+		}
+	} catch (error) {
+		console.warn(
+			'Failed to fetch WordPress version online. Trying offline version.'
 		);
 	}
 
-	return {
-		resolvedWordPressVersion: version as string,
-		isDeveloperBuild,
-	};
+	const offlineFallbackVersion = await getOfflineVersion(wordPressVersion);
+
+	if (offlineFallbackVersion) {
+		return {
+			resolvedWordPressVersion: offlineFallbackVersion,
+			isDeveloperBuild,
+		};
+	}
+
+	throw new Error(
+		`Failed to resolve ${wordPressVersion} WordPress version. Please check your internet connection or try again later.`
+	);
 }


### PR DESCRIPTION
- Closes: https://github.com/WordPress/playground-tools/issues/214

## What?

Resolves to an actual WordPress version when starting `wp-now` with `--wp=latest|trunk|nightly`.

It keeps working while offline by caching the version aliases in a file: `~/.wp-now/wp-version-offline-alias.json`

## Why?

In https://github.com/WordPress/playground-tools/issues/214, it was reported that running `--wp=latest` might start the server with an outdated version of WordPress because we're caching the version locally by the alias (which changes between published versions) and not the version number.

## How?

Instead of having `latest`, `trunk` and `nightly` folders, we're resolving these aliases using the `api.wordpress.org` endpoint to actual versions, and caching the version number instead of the alias.

After confirmation this is the approach we want to move forward with, I'll add/update tests.

## Testing Instructions

Build it locally and verify that following commands produce the following outputs:

| Command | CLI options output |
| ----------- | ------- |
| `start` | `wp: 6.5.5 (resolved from alias: latest)` |
| `start --wp=latest` | `wp: 6.5.5 (resolved from alias: latest)` |
| `start --wp=trunk` | `wp: 6.7-alpha-xxxx (resolved from alias: trunk)` |
| `start --wp=nightly` | `wp: 6.7-alpha-xxxx (resolved from alias: nightly)` |
| `start --wp=6.3` | `wp: 6.3` |