### PR TITLE
Playground block: Add i18n support

### DIFF
--- a/packages/wordpress-playground-block/src/components/file-name-modal.tsx
+++ b/packages/wordpress-playground-block/src/components/file-name-modal.tsx
@@ -4,6 +4,7 @@ import {
 	// @ts-ignore
 	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
+import { __ } from '../i18n';
 import { useState } from '@wordpress/element';
 import { EditorFile } from '..';
 
@@ -45,7 +46,7 @@ export function FileNameModal({
 				<div style={{ marginTop: '1em' }}>
 					<InputControl
 						value={editedFileName}
-						label="File name"
+						label={__('File name')}
 						autoFocus
 						onChange={(value: any) => {
 							setEditedFileName(value || '');
@@ -55,22 +56,24 @@ export function FileNameModal({
 				<div style={{ marginTop: '1em' }}>
 					<InputControl
 						value={editedFileUrl}
-						label="Load content from remote URL (optional)"
+						label={__('Load content from remote URL (optional)')}
 						onChange={(value: any) => {
 							setEditedFileUrl(value || '');
 						}}
 					/>
 				</div>
-				{isLoading && 'Fetching the remote file...'}
+				{isLoading && __('Fetching the remote file...')}
 				{error && (
 					<p style={{ color: 'red', marginTop: '1em' }}>
-						The file could not be fetched. Check the browser dev
-						tools for more information.
+						{__(
+							'The file could not be fetched. ' +
+								'Check the browser dev tools for more information.'
+						)}
 					</p>
 				)}
 				<br />
 				<Button variant="primary" type="submit">
-					Done
+					{__('Done')}
 				</Button>
 			</form>
 		</Modal>

--- a/packages/wordpress-playground-block/src/components/playground-preview/file-management-modals.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/file-management-modals.tsx
@@ -1,4 +1,5 @@
 import { useState, forwardRef, useImperativeHandle } from '@wordpress/element';
+import { __ } from '../../i18n';
 
 import type { EditorFile } from '../../index';
 import { FileNameModal } from '../file-name-modal';
@@ -83,7 +84,7 @@ export default forwardRef(function FileManagementModals(
 		<>
 			{isEditFileNameModalOpen && (
 				<FileNameModal
-					title="Edit file name or URL"
+					title={__('Edit file name or URL')}
 					file={files[activeFileIndex]}
 					onRequestClose={() => setEditFileNameModalOpen(false)}
 					onSave={updateActiveFile}
@@ -94,7 +95,7 @@ export default forwardRef(function FileManagementModals(
 
 			{isNewFileModalOpen && (
 				<FileNameModal
-					title="Create new file"
+					title={__('Create new file')}
 					onRequestClose={() => setNewFileModalOpen(false)}
 					onSave={createNewFile}
 					isLoading={downloadingFile}

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -13,7 +13,12 @@ import {
 	phpVar,
 	// @ts-ignore
 } from 'https://playground.wordpress.net/client/index.js';
-import { useEffect, useRef, useState } from '@wordpress/element';
+import {
+	useEffect,
+	useRef,
+	useState,
+	createInterpolateElement,
+} from '@wordpress/element';
 import { Button, Spinner } from '@wordpress/components';
 import {
 	Icon,
@@ -34,6 +39,7 @@ import {
 	TranspilationFailure,
 	transpilePluginFiles,
 } from './transpile-plugin-files';
+import { __, _x, sprintf } from '../../i18n';
 
 export type PlaygroundDemoProps = Attributes & {
 	inBlockEditor: boolean;
@@ -87,7 +93,10 @@ export default function PlaygroundPreview({
 	logInUser,
 	createNewPost,
 	createNewPostType = 'post',
-	createNewPostTitle = 'New post',
+	createNewPostTitle = _x(
+		'New post',
+		'default title of new post created by blueprint'
+	),
 	createNewPostContent = '',
 	redirectToPost,
 	redirectToPostType = 'front',
@@ -349,19 +358,21 @@ export default function PlaygroundPreview({
 		'is-one-under-another': !codeEditorSideBySide,
 		'is-side-by-side': codeEditorSideBySide,
 	});
-	const iframeCreationWarningForRunningCode =
+	const iframeCreationWarningForRunningCode = __(
 		'This button runs the code in the Preview iframe. ' +
-		'If the Preview iframe has not yet been activated, this ' +
-		'button creates the Preview iframe which contains a full ' +
-		'WordPress website and may be a challenge for screen readers.';
-	const iframeCreationWarningForActivation =
+			'If the Preview iframe has not yet been activated, this ' +
+			'button creates the Preview iframe which contains a full ' +
+			'WordPress website and may be a challenge for screen readers.'
+	);
+	const iframeCreationWarningForActivation = __(
 		'This button creates the Preview iframe containing a full ' +
-		'WordPress website which may be a challenge for screen readers.';
+			'WordPress website which may be a challenge for screen readers.'
+	);
 
 	return (
 		<>
 			<section
-				aria-label="WordPress Playground"
+				aria-label={__('WordPress Playground')}
 				className={mainContainerClass}
 			>
 				{codeEditor && (
@@ -377,7 +388,7 @@ export default function PlaygroundPreview({
 						<div className="file-tabs">
 							{isFilesLoading ? (
 								<div className="file-tab file-tab-loading">
-									<Spinner /> Loading files...
+									<Spinner /> {__('Loading files...')}
 								</div>
 							) : (
 								files.map((file, index) => (
@@ -390,8 +401,18 @@ export default function PlaygroundPreview({
 										}`}
 										aria-label={
 											isErrorLogFile(file)
-												? `Read-only file: ${file.name}`
-												: `File: ${file.name}`
+												? // translators: %s is a file name
+												  sprintf(
+														__(
+															'Read-only file: %s'
+														),
+														file.name
+												  )
+												: // translators: %s is a file name
+												  sprintf(
+														__('File: %s'),
+														file.name
+												  )
 										}
 										aria-current={
 											index === activeFileIndex
@@ -418,7 +439,10 @@ export default function PlaygroundPreview({
 							)}
 							{showAddNewFile && (
 								<Button
-									aria-label="Add File"
+									aria-label={
+										// translators: add source code file to code editor
+										__('Add File')
+									}
 									variant="secondary"
 									className="file-tab file-tab-extra"
 									onClick={() =>
@@ -431,7 +455,7 @@ export default function PlaygroundPreview({
 								</Button>
 							)}
 							<Button
-								aria-label="Download Code as a Zip file"
+								aria-label={__('Download Code as a Zip file')}
 								variant="secondary"
 								className="file-tab file-tab-extra"
 								onClick={() => {
@@ -478,7 +502,11 @@ export default function PlaygroundPreview({
 											}}
 											className="wordpress-playground-block-button button-non-destructive"
 										>
-											<Icon icon={edit} /> Edit file name
+											<Icon icon={edit} />{' '}
+											{
+												// translators: edit source code file name
+												__('Edit file name')
+											}
 										</button>
 									)}
 									{!isErrorLogFile(activeFile) &&
@@ -496,7 +524,10 @@ export default function PlaygroundPreview({
 												<Icon
 													icon={cancelCircleFilled}
 												/>{' '}
-												Remove file
+												{
+													// translators: remove file from code editor
+													__('Remove file')
+												}
 											</button>
 										)}
 								</div>
@@ -517,14 +548,20 @@ export default function PlaygroundPreview({
 										: undefined
 								}
 							>
-								Run
+								{
+									// translators: verb: run code in Playground
+									__('Run')
+								}
 							</Button>
 						</div>
 					</div>
 				)}
 				<div className="playground-container">
 					<span className="screen-reader-text">
-						Beginning of Playground Preview
+						{
+							// translators: screen reader text noting beginning of the playground iframe
+							__('Beginning of Playground Preview')
+						}
 					</span>
 					<a
 						href="#"
@@ -536,7 +573,10 @@ export default function PlaygroundPreview({
 							}
 						}}
 					>
-						Skip Playground Preview
+						{
+							// translators: verb: skip over the playground iframe
+							__('Skip Playground Preview')
+						}
 					</a>
 					{!isLivePreviewActivated && (
 						<div className="playground-activation-placeholder">
@@ -548,16 +588,18 @@ export default function PlaygroundPreview({
 									iframeCreationWarningForActivation
 								}
 							>
-								Activate Live Preview
+								{__('Activate Live Preview')}
 							</Button>
 						</div>
 					)}
 					{transpilationFailures?.length > 0 && (
 						<div className="playground-transpilation-failures">
-							<h3>Transpilation Error</h3>
+							<h3>{__('Transpilation Error')}</h3>
 							<p>
-								There were errors while transpiling the code.
-								Please fix the errors and try again.
+								{__(
+									'There were errors while transpiling the code. ' +
+										'Please fix the errors and try again.'
+								)}
 							</p>
 							<ul>
 								{transpilationFailures.map(
@@ -573,7 +615,9 @@ export default function PlaygroundPreview({
 					)}
 					{isLivePreviewActivated && (
 						<iframe
-							aria-label="Live Preview in WordPress Playground"
+							aria-label={__(
+								'Live Preview in WordPress Playground'
+							)}
 							key="playground-iframe"
 							ref={iframeRef}
 							className="playground-iframe"
@@ -584,7 +628,10 @@ export default function PlaygroundPreview({
 						tabIndex={-1}
 						ref={afterPreviewRef}
 					>
-						End of Playground Preview
+						{
+							// translators: screen reader text noting end of Playground preview
+							__('End of Playground Preview')
+						}
 					</span>
 				</div>
 			</section>
@@ -594,11 +641,22 @@ export default function PlaygroundPreview({
 					className="demo-footer__link"
 					target="_blank"
 				>
-					<span className="demo-footer__powered">Powered by</span>
-					<Icon className="demo-footer__icon" icon={wordpress} />
-					<span className="demo-footer__link-text">
-						WordPress Playground
-					</span>
+					{createInterpolateElement(
+						// translators: powered-by label with embedded icon. please leave markup tags intact, including numbering.
+						__(
+							'<span1>Powered by</span1> <Icon /> <span2>WordPress Playground</span2>'
+						),
+						{
+							span1: <span className="demo-footer__powered" />,
+							Icon: (
+								<Icon
+									className="demo-footer__icon"
+									icon={wordpress}
+								/>
+							),
+							span2: <span className="demo-footer__link-text" />,
+						}
+					)}
 				</a>
 			</footer>
 		</>

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -401,15 +401,15 @@ export default function PlaygroundPreview({
 										}`}
 										aria-label={
 											isErrorLogFile(file)
-												? // translators: %s is a file name
-												  sprintf(
+												? sprintf(
+														// translators: %s is a file name
 														__(
 															'Read-only file: %s'
 														),
 														file.name
 												  )
-												: // translators: %s is a file name
-												  sprintf(
+												: sprintf(
+														// translators: %s is a file name
 														__('File: %s'),
 														file.name
 												  )

--- a/packages/wordpress-playground-block/src/components/playground-preview/use-editor-files.ts
+++ b/packages/wordpress-playground-block/src/components/playground-preview/use-editor-files.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect } from '@wordpress/element';
+import { __, sprintf } from '../../i18n';
 import type { EditorFile } from '../../index';
 
 export type UseEditorFilesOptions = {
@@ -50,8 +51,16 @@ export default function useEditorFiles(
 			updateFile(
 				(existingFile) => ({
 					...existingFile,
-					contents: `Failed to fetch the remote file from ${file.remoteUrl}`,
-					name: existingFile.name + ' (Failed to fetch)',
+					contents: sprintf(
+						/* translators: %s: A URL for a remote file. */
+						__('Failed to fetch the remote file from %s'),
+						file.remoteUrl
+					),
+					name: sprintf(
+						/* translators: %s: A file name. */
+						__('%s (Failed to fetch)'),
+						existingFile.name
+					),
 				}),
 				files.indexOf(file)
 			);

--- a/packages/wordpress-playground-block/src/edit.tsx
+++ b/packages/wordpress-playground-block/src/edit.tsx
@@ -497,10 +497,12 @@ export default withBase64Attrs(function Edit({
 										/>
 										{redirectToPost && (
 											<ToggleGroupControl
-												label={_x(
+												label={
 													// translators: how to redirect to post created by blueprint
-													'Create new redirect: redirect to'
-												)}
+													__(
+														'Create new redirect: redirect to'
+													)
+												}
 												value={redirectToPostType}
 												onChange={(value: any) => {
 													setAttributes({
@@ -512,19 +514,23 @@ export default withBase64Attrs(function Edit({
 											>
 												<ToggleGroupControlOption
 													value="front"
-													label={_x(
+													label={
 														// translators: place to view the post created by blueprint
-														'Front page',
-														'post created by blueprint'
-													)}
+														_x(
+															'Front page',
+															'post created by blueprint'
+														)
+													}
 												/>
 												<ToggleGroupControlOption
 													value="admin"
-													label={_x(
+													label={
 														// translators: place to edit the post created by blueprint
-														'Edit screen',
-														'post created by blueprint'
-													)}
+														_x(
+															'Edit screen',
+															'post created by blueprint'
+														)
+													}
 												/>
 											</ToggleGroupControl>
 										)}

--- a/packages/wordpress-playground-block/src/edit.tsx
+++ b/packages/wordpress-playground-block/src/edit.tsx
@@ -23,6 +23,7 @@ import {
 	base64DecodeBlockAttributes,
 	base64EncodeBlockAttributes,
 } from './base64';
+import { __, _x } from './i18n';
 
 /**
  * Some WordPress installations are overly eager with their HTML entity encoding
@@ -156,14 +157,14 @@ export default withBase64Attrs(function Edit({
 				{...attributes}
 			/>
 			<InspectorControls>
-				<Panel header="Settings">
-					<PanelBody title="General" initialOpen={true}>
+				<Panel header={__('Settings')}>
+					<PanelBody title={__('General')} initialOpen={true}>
 						<ToggleControl
-							label="Require live preview activation"
+							label={__('Require live preview activation')}
 							help={
 								requireLivePreviewActivation
-									? 'User must click to load the preview.'
-									: 'Preview begins loading immediately.'
+									? __('User must click to load the preview.')
+									: __('Preview begins loading immediately.')
 							}
 							checked={requireLivePreviewActivation}
 							onChange={() => {
@@ -174,13 +175,13 @@ export default withBase64Attrs(function Edit({
 							}}
 						/>
 					</PanelBody>
-					<PanelBody title="Code editor" initialOpen={true}>
+					<PanelBody title={__('Code editor')} initialOpen={true}>
 						<ToggleControl
-							label="Code editor"
+							label={__('Code editor')}
 							help={
 								codeEditor
-									? 'Code editor enabled.'
-									: 'Code editor disabled.'
+									? __('Code editor enabled.')
+									: __('Code editor disabled.')
 							}
 							checked={codeEditor}
 							onChange={() => {
@@ -192,11 +193,11 @@ export default withBase64Attrs(function Edit({
 						{codeEditor && (
 							<>
 								<ToggleControl
-									label="Side by side"
+									label={__('Side by side')}
 									help={
 										codeEditorSideBySide
-											? 'Code editor is to the left.'
-											: 'Code editor is at the top.'
+											? __('Code editor is to the left.')
+											: __('Code editor is at the top.')
 									}
 									checked={codeEditorSideBySide}
 									onChange={() => {
@@ -207,11 +208,11 @@ export default withBase64Attrs(function Edit({
 									}}
 								/>
 								<ToggleControl
-									label="Read only"
+									label={__('Read only')}
 									help={
 										codeEditorReadOnly
-											? 'Code editor is read only.'
-											: 'Code editor is editable.'
+											? __('Code editor is read only.')
+											: __('Code editor is editable.')
 									}
 									checked={codeEditorReadOnly}
 									onChange={() => {
@@ -222,12 +223,12 @@ export default withBase64Attrs(function Edit({
 									}}
 								/>
 								<ToggleControl
-									label="Transpile JSX to JS"
-									help={
+									label={__('Transpile JSX to JS')}
+									help={__(
 										`Transpiles JSX syntax to JS using esbuild. Only the JSX tags are ` +
-										`transpiled. Imports and other advanced ESM syntax features are ` +
-										`preserved.`
-									}
+											`transpiled. Imports and other advanced ES module syntax features are ` +
+											`preserved.`
+									)}
 									checked={codeEditorTranspileJsx}
 									onChange={() => {
 										setAttributes({
@@ -237,11 +238,11 @@ export default withBase64Attrs(function Edit({
 									}}
 								/>
 								<ToggleControl
-									label="Multiple files"
+									label={__('Multiple files')}
 									help={
 										codeEditorMultipleFiles
-											? 'Multiple files allowed.'
-											: 'Single file allowed.'
+											? __('Multiple files allowed.')
+											: __('Single file allowed.')
 									}
 									checked={codeEditorMultipleFiles}
 									onChange={() => {
@@ -252,7 +253,7 @@ export default withBase64Attrs(function Edit({
 									}}
 								/>
 								<ToggleControl
-									label='Include "error_log" file'
+									label={__('Include "error_log" file')}
 									checked={codeEditorErrorLog}
 									onChange={() => {
 										setAttributes({
@@ -269,6 +270,7 @@ export default withBase64Attrs(function Edit({
 								to prevent the user from selecting the Editor script mode.
 
 								@see https://github.com/WordPress/playground-tools/issues/196
+								@todo Before re-enabling, add i18n support.
 								*/}
 								<div style={{ display: 'none' }}>
 									<SelectControl
@@ -337,21 +339,30 @@ export default withBase64Attrs(function Edit({
 							</>
 						)}
 					</PanelBody>
-					<PanelBody title="Blueprint" initialOpen={false}>
+					<PanelBody title={__('Blueprint')} initialOpen={false}>
 						<SelectControl
-							label="Blueprint source"
+							label={__('Blueprint source')}
 							value={configurationSource}
 							options={[
 								{
-									label: 'Generate from block attributes',
+									label: __(
+										'Generate from block attributes',
+										'source of Blueprint content'
+									),
 									value: 'block-attributes',
 								},
 								{
-									label: 'URL',
+									label: _x(
+										'URL',
+										'source of Blueprint content'
+									),
 									value: 'blueprint-url',
 								},
 								{
-									label: 'JSON (paste it below)',
+									label: _x(
+										'JSON (paste it below)',
+										'source of Blueprint content'
+									),
 									value: 'blueprint-json',
 								},
 							]}
@@ -360,19 +371,19 @@ export default withBase64Attrs(function Edit({
 									configurationSource: newConfigurationSource,
 								});
 							}}
-							help={
+							help={__(
 								'Playground is configured using Blueprints. Select the source ' +
-								"of the Blueprint you'd like to use for this Playground instance."
-							}
+									"of the Blueprint you'd like to use for this Playground instance."
+							)}
 						/>
 						{configurationSource === 'block-attributes' && (
 							<>
 								<ToggleControl
-									label="Log in automatically"
+									label={__('Log in automatically')}
 									help={
 										logInUser
-											? 'User will be logged in.'
-											: "User won't be logged in."
+											? __('User will be logged in.')
+											: __("User won't be logged in.")
 									}
 									checked={logInUser}
 									onChange={() => {
@@ -382,11 +393,15 @@ export default withBase64Attrs(function Edit({
 									}}
 								/>
 								<ToggleControl
-									label="Create new post or page"
+									label={__('Create new post or page')}
 									help={
 										createNewPost
-											? 'New post or page will be created.'
-											: 'No new posts or pages will be created.'
+											? __(
+													'New post or page will be created.'
+											  )
+											: __(
+													'No new posts or pages will be created.'
+											  )
 									}
 									checked={createNewPost}
 									onChange={() => {
@@ -398,7 +413,10 @@ export default withBase64Attrs(function Edit({
 								{createNewPost && (
 									<>
 										<ToggleGroupControl
-											label="Create new: post type"
+											label={_x(
+												'Create new: post type',
+												'optional blueprint step'
+											)}
 											value={createNewPostType}
 											onChange={(value: any) => {
 												setAttributes({
@@ -410,11 +428,17 @@ export default withBase64Attrs(function Edit({
 										>
 											<ToggleGroupControlOption
 												value="post"
-												label="Post"
+												label={_x(
+													'Post',
+													'noun: WordPress post type'
+												)}
 											/>
 											<ToggleGroupControlOption
 												value="page"
-												label="Page"
+												label={_x(
+													'Page',
+													'noun: WordPress post type'
+												)}
 											/>
 										</ToggleGroupControl>
 										<InputControl
@@ -424,8 +448,15 @@ export default withBase64Attrs(function Edit({
 													createNewPostTitle: value,
 												});
 											}}
-											label="Create new: title"
-											placeholder="Hello World!"
+											label={_x(
+												'Create new: title',
+												'title for new post or page created by blueprint'
+											)}
+											placeholder={_x(
+												'Hello World!',
+												'placeholder text: ' +
+													'title for new post or page created by blueprint'
+											)}
 										/>
 										<TextareaControl
 											value={createNewPostContent}
@@ -434,15 +465,27 @@ export default withBase64Attrs(function Edit({
 													createNewPostContent: value,
 												});
 											}}
-											label="Create new: content"
-											help="Gutenberg editor content of the post"
+											label={_x(
+												'Create new: content',
+												'content for new post or page created by blueprint'
+											)}
+											help={__(
+												'Gutenberg editor content of the post'
+											)}
 										/>
 										<ToggleControl
-											label="Create new: redirect to post"
+											label={_x(
+												'Create new: redirect to post',
+												'optional blueprint step'
+											)}
 											help={
 												redirectToPost
-													? 'User will be redirected.'
-													: "User won't be redirected."
+													? __(
+															'User will be redirected.'
+													  )
+													: __(
+															"User won't be redirected."
+													  )
 											}
 											checked={redirectToPost}
 											onChange={() => {
@@ -454,7 +497,10 @@ export default withBase64Attrs(function Edit({
 										/>
 										{redirectToPost && (
 											<ToggleGroupControl
-												label="Create new redirect: redirect to"
+												label={_x(
+													// translators: how to redirect to post created by blueprint
+													'Create new redirect: redirect to'
+												)}
 												value={redirectToPostType}
 												onChange={(value: any) => {
 													setAttributes({
@@ -466,11 +512,19 @@ export default withBase64Attrs(function Edit({
 											>
 												<ToggleGroupControlOption
 													value="front"
-													label="Front page"
+													label={_x(
+														// translators: place to view the post created by blueprint
+														'Front page',
+														'post created by blueprint'
+													)}
 												/>
 												<ToggleGroupControlOption
 													value="admin"
-													label="Edit screen"
+													label={_x(
+														// translators: place to edit the post created by blueprint
+														'Edit screen',
+														'post created by blueprint'
+													)}
 												/>
 											</ToggleGroupControl>
 										)}
@@ -484,9 +538,16 @@ export default withBase64Attrs(function Edit({
 												landingPageUrl: value,
 											});
 										}}
-										label="Landing page"
-										help="Define where to redirect after Playground is loaded."
-										placeholder="URL to redirect to after load (eg. /wp-admin/)"
+										label={_x(
+											'Landing page',
+											'where to redirect after Playground is loaded'
+										)}
+										help={__(
+											'Define where to redirect after Playground is loaded.'
+										)}
+										placeholder={__(
+											'URL to redirect to after load (eg. /wp-admin/)'
+										)}
 									/>
 								)}
 								{['WP_DEBUG', 'WP_SCRIPT_DEBUG'].map(
@@ -524,9 +585,11 @@ export default withBase64Attrs(function Edit({
 										blueprintUrl: value,
 									});
 								}}
-								label="Blueprint URL"
-								help="Load Blueprint from this URL."
-								placeholder="URL to load the Blueprint from"
+								label={__('Blueprint URL')}
+								help={__('Load Blueprint from this URL.')}
+								placeholder={__(
+									'URL to load the Blueprint from'
+								)}
 							/>
 						)}
 						{configurationSource === 'blueprint-json' && (
@@ -537,8 +600,8 @@ export default withBase64Attrs(function Edit({
 										blueprint: value,
 									});
 								}}
-								label="Blueprint"
-								help="JSON file with playground blueprint"
+								label={_x('Blueprint', 'raw Blueprint JSON')}
+								help={__('JSON file with playground blueprint')}
 							/>
 						)}
 					</PanelBody>

--- a/packages/wordpress-playground-block/src/i18n.ts
+++ b/packages/wordpress-playground-block/src/i18n.ts
@@ -1,0 +1,9 @@
+import { createI18n, sprintf as coreSprintf } from '@wordpress/i18n';
+
+const i18n = createI18n(undefined, 'interactive-code-block');
+
+export const __ = i18n.__;
+export const _x = i18n._x;
+export const _n = i18n._n;
+export const _nx = i18n._nx;
+export const sprintf = coreSprintf;

--- a/packages/wordpress-playground-block/src/index.ts
+++ b/packages/wordpress-playground-block/src/index.ts
@@ -5,6 +5,7 @@ import {
 	useEffect,
 	useState,
 } from '@wordpress/element';
+import { __ } from './i18n';
 
 import metadata from './block.json';
 import './style.scss';
@@ -67,7 +68,7 @@ registerBlockType<Attributes>(metadata.name, {
 		}, []);
 		if (!isLoaded) {
 			return createElement('span', {}, [
-				'Loading the WordPress Playground Block...',
+				__('Loading the WordPress Playground Block...'),
 			]);
 		}
 		return createElement(EditComponent as any, props);

--- a/packages/wordpress-playground-block/wordpress-playground-block.php
+++ b/packages/wordpress-playground-block/wordpress-playground-block.php
@@ -8,7 +8,7 @@
  * Author:            Dawid Urbański, Adam Zieliński
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
- * Text Domain:       wordpress-playground-block
+ * Text Domain:       interactive-code-block
  *
  * @package WordPress/playground-block
  */


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

This PR adds i18n support to enable translation of Playground block strings.

## Why?

Before this PR, Playground block strings were not rendered using i18n facilities and were not translatable.

## How?

This PR uses `@wordpress/i18n`, adds a local i18n module with the correct text domain, and attempts to convert all fixed strings to using the i18n API.

## Testing Instructions

Smoke test. Use the block in the editor and on the front end. Play with different block settings toggles, and ensure the user visible text is intact.

@akirk Somehow it doesn't appear possible to select you as a reviewer when creating this PR. Would you be willing to review this as well? I am relatively new to i18n APIs and would love to learn from your wisdom here.
