### PR TITLE
Playground block: Allow brandonpayton to release new versions

### DIFF
--- a/.github/workflows/release-playground-block.yml
+++ b/.github/workflows/release-playground-block.yml
@@ -10,7 +10,8 @@ jobs:
                 github.actor == 'dmsnell' ||
                 github.actor == 'bgrgicak' ||
                 github.actor == 'sejas' ||
-                github.actor == 'danielbachchuber'
+                github.actor == 'danielbachchuber' ||
+                github.actor == 'brandonpayton'
             )
 
         # Specify runner + deployment step


### PR DESCRIPTION
This PR updates the release-playground-block workflow to allow me to tag new releases.