### PR TITLE
Playground block minor dotorg readme fixes

### DIFF
--- a/packages/wordpress-playground-block/README.plugindirectory.txt
+++ b/packages/wordpress-playground-block/README.plugindirectory.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg, dawidurbanski, zieladam
 Tags: code, interactive, playground, block
 Requires at least: 6.0
-Tested up to: 6.4
+Tested up to: 6.6
 Stable tag: 0.2.10
 Requires PHP: 7.0
 License: GPLv2

--- a/packages/wordpress-playground-block/README.plugindirectory.txt
+++ b/packages/wordpress-playground-block/README.plugindirectory.txt
@@ -7,7 +7,7 @@ Stable tag: 0.2.10
 Requires PHP: 7.0
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
-This WordPress block embeds WordPress Playground in your posts and pages. You can also include an interactive code editor to demonstrate and teach your readers how WordPress plugins are built.
+This WordPress block embeds WordPress Playground in your posts and pages. An optional interactive code editor allows readers to learn and explore.
 
 == Description ==
 


### PR DESCRIPTION
This PR makes a couple of fixes to the Playground block's WordPress.org README:
- Bump tested WP version to 6.6
- Edit short description to be less than 150 characters. We are currently getting a warning about this.