### PR TITLE
Playground block: remove skip link and preview boundary markers in full-page mode

### DIFF
--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -614,21 +614,23 @@ export default function PlaygroundPreview({
 							__('Beginning of Playground Preview')
 						}
 					</span>
-					<a
-						href="#"
-						className="screen-reader-text"
-						onClick={(event) => {
-							event.preventDefault();
-							if (afterPreviewRef.current) {
-								afterPreviewRef.current.focus();
+					{!inFullPageView && (
+						<a
+							href="#"
+							className="screen-reader-text"
+							onClick={(event) => {
+								event.preventDefault();
+								if (afterPreviewRef.current) {
+									afterPreviewRef.current.focus();
+								}
+							}}
+						>
+							{
+								// translators: verb: skip over the playground iframe
+								__('Skip Playground Preview')
 							}
-						}}
-					>
-						{
-							// translators: verb: skip over the playground iframe
-							__('Skip Playground Preview')
-						}
-					</a>
+						</a>
+					)}
 					{!isLivePreviewActivated && (
 						<div className="playground-activation-placeholder">
 							<Button

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -608,28 +608,30 @@ export default function PlaygroundPreview({
 					</div>
 				)}
 				<div className="playground-container">
-					<span className="screen-reader-text">
-						{
-							// translators: screen reader text noting beginning of the playground iframe
-							__('Beginning of Playground Preview')
-						}
-					</span>
 					{!inFullPageView && (
-						<a
-							href="#"
-							className="screen-reader-text"
-							onClick={(event) => {
-								event.preventDefault();
-								if (afterPreviewRef.current) {
-									afterPreviewRef.current.focus();
+						<>
+							<span className="screen-reader-text">
+								{
+									// translators: screen reader text noting beginning of the playground iframe
+									__('Beginning of Playground Preview')
 								}
-							}}
-						>
-							{
-								// translators: verb: skip over the playground iframe
-								__('Skip Playground Preview')
-							}
-						</a>
+							</span>
+							<a
+								href="#"
+								className="screen-reader-text"
+								onClick={(event) => {
+									event.preventDefault();
+									if (afterPreviewRef.current) {
+										afterPreviewRef.current.focus();
+									}
+								}}
+							>
+								{
+									// translators: verb: skip over the playground iframe
+									__('Skip Playground Preview')
+								}
+							</a>
+						</>
 					)}
 					{!isLivePreviewActivated && (
 						<div className="playground-activation-placeholder">
@@ -676,16 +678,18 @@ export default function PlaygroundPreview({
 							className="playground-iframe"
 						></iframe>
 					)}
-					<span
-						className="screen-reader-text wordpress-playground-end-of-preview"
-						tabIndex={-1}
-						ref={afterPreviewRef}
-					>
-						{
-							// translators: screen reader text noting end of Playground preview
-							__('End of Playground Preview')
-						}
-					</span>
+					{!inFullPageView && (
+						<span
+							className="screen-reader-text wordpress-playground-end-of-preview"
+							tabIndex={-1}
+							ref={afterPreviewRef}
+						>
+							{
+								// translators: screen reader text noting end of Playground preview
+								__('End of Playground Preview')
+							}
+						</span>
+					)}
 				</div>
 			</div>
 			<footer className="wordpress-playground-footer">


### PR DESCRIPTION
## What?

This PR removes the skip-preview-link and the begin/end preview markers.

## Why?

The skip-preview-link and the begin/end preview markers are not necessary in full-page mode because the Playground block is the only thing on the page.

Related to #293

## Testing Instructions

- Run `npx nx dev wordpress-playground-block`
- View a post containing a Playground block
- Inspect the Preview iframe in the dev tools, and note the presence of the skip link and begin/end markers as siblings to the preview iframe
- Click "Open in New Tab" to open the block in full page mode
- Inspect the Preview iframe in the dev tools, and note the absence of the skip link and begin/end markers as siblings to the preview iframe
