### PR TITLE
Playground block: Hide open-in-tab arrow from screen readers

### DIFF
--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -420,6 +420,13 @@ export default function PlaygroundPreview({
 						onClick={() => {
 							window.open(getFullPageUrl(), '_blank');
 						}}
+						aria-label={
+							// Add dedicated aria-label for screen readers
+							// because an arrow is added to the main button
+							// label via CSS pseudo-element, and our users with
+							// screen readers do not need an arrow read to them.
+							__('Open in New Tab')
+						}
 					>
 						{__('Open in New Tab')}
 					</Button>


### PR DESCRIPTION
## What?

This PR stops the Open-in-New-Tab arrow icon from being read to screen readers.

Related to #330 

## Why?

Our users with screen readers do not need an arrow read to them.

## How?

This PR adds an aria-label attribute to the button so that is read instead of the label with the arrow.

## Testing Instructions

- Run `npx nx dev wordpress-playground-block` to start a dev server
- Open a post with a Playground block and confirm that a screen reader does not read "Northeast arrow" as part of the Open-in-New-Tab button label.