### PR TITLE
Playground block: Add missing readonly file annotations for a11y

### DIFF
--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -458,6 +458,7 @@ export default function PlaygroundPreview({
 											'file-tab-active'
 										}`}
 										aria-label={
+											codeEditorReadOnly ||
 											isErrorLogFile(file)
 												? sprintf(
 														// translators: %s is a file name
@@ -538,7 +539,10 @@ export default function PlaygroundPreview({
 										currentFileExtension || 'js'
 									),
 								]}
-								readOnly={codeEditorReadOnly}
+								readOnly={
+									codeEditorReadOnly ||
+									isErrorLogFile(files[activeFileIndex])
+								}
 								onChange={(value) =>
 									updateFile((file) => ({
 										...file,


### PR DESCRIPTION
## What?

This PR fixes a couple of related accessibility bugs where either the code editor or the filename tabs are not properly marked as readonly.
1. When the error log file is enabled, it is labeled as readonly, but the code editor is not.
2. When the block is configured to make all files as readonly, the code editor is always `aria-readonly="true"`, but the filename tabs do not all have `aria-label`'s that include the readonly status.

Related to #331

## Testing Instructions

- Run `npx nx dev wordpress-playground-block` to start a dev server
- Create a post with two Playground blocks, one readonly the other not. Both should contain the PHP error log.
- View the post, select the readonly Playground block
- Using a screen reader click the file tab buttons of each block and confirm they start with "Read-only file" or "File" as expected.
- Using the dev tools, inspect the code editor for the readonly block and confirm that it has an `aria-readonly="true"` attribute no matter what file is selected.
- Using the dev tools, inspect the code editor for the non-readonly block and confirm that it only has an `aria-readonly="true"` attribute when the PHP error log is selected.
