### PR TITLE
Playground block: Fix powered-by link spelling in screen readers

### DIFF
--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -708,21 +708,39 @@ export default function PlaygroundPreview({
 					href="https://w.org/playground"
 					className="wordpress-playground-footer__link"
 					target="_blank"
+					aria-label={
+						// Provide dedicated ARIA label because NVDA does not
+						// always spell out spaces as expected in the powered-by
+						// HTML with the embedded icon.
+						// Conversely, macOS Voiceover appears to disregard this
+						// attribute when spelling out the link text.
+						__('Powered by WordPress Playground')
+					}
 				>
 					{createInterpolateElement(
 						// translators: powered-by label with embedded icon. please leave markup tags intact, including numbering.
 						__(
-							'<span1>Powered by</span1> <Icon /> <span2>WordPress Playground</span2>'
+							'<span1>Powered by</span1><WordPressIcon /><span2>WordPress Playground</span2>'
 						),
 						{
 							span1: (
 								<span className="wordpress-playground-footer__powered" />
 							),
-							Icon: (
-								<Icon
-									className="wordpress-playground-footer__icon"
-									icon={wordpress}
-								/>
+							WordPressIcon: (
+								<>
+									{
+										// a11y: Use non-breaking space because
+										// macOS Voiceover does not otherwise
+										// spell out the space in Safari.
+										<span className="wordpress-playground-footer__spacing">
+											&nbsp;
+										</span>
+									}
+									<Icon
+										icon={wordpress}
+										className="wordpress-playground-footer__icon"
+									/>
+								</>
 							),
 							span2: (
 								<span className="wordpress-playground-footer__link-text" />

--- a/packages/wordpress-playground-block/src/style.scss
+++ b/packages/wordpress-playground-block/src/style.scss
@@ -208,8 +208,13 @@
 			opacity: 0.7;
 		}
 		.wordpress-playground-footer__link {
+			.wordpress-playground-footer__spacing {
+				display: inline-block;
+				width: 0;
+				height: 0;
+			}
 			.wordpress-playground-footer__icon {
-				margin-top: -4px;
+				margin: -4px 2px auto 2px;
 				fill: $color;
 				vertical-align: middle;
 			}


### PR DESCRIPTION
## What and why?

Prior to this PR both macOS Voiceover and NVDA on Windows did not spell out the expected number of spaces between words in the "Powered by WordPress Playground" HTML.

Related to #291

## How?

Getting this right was surprisingly hard.

This PR does the following:
- Adds an `aria-label` attribute which fixes the problem for NVDA
- Removes a space after the "W" icon. Safari was reading "space-space" because of the spaces on each side the of the "W" icon.
- In order to achieve consistent spacing around the "W" icon, visually hides the space next to the "W" icon and sets a left and right margin so there is still spacing between the icon and the "Powered by" and "WordPress Playground" spans.

## Testing Instructions

- View a post containing a Playground block in Safari
- Turn on Voiceover, select the powered-by link, use the arrow keys to iterate through the letters in the link and make sure it spells out "Powered by WordPress Playground" with exactly one space between words.
- In Windows, install NVDA
- In Windows, view a post containing a Playground block in Microsoft Edge
- Turn on NVDA, select the powered-by link, use the arrow keys to iterate through the letters in the link and make sure it spells out "Powered by WordPress Playground" with exactly one space between words.