### PR TITLE
Playground block: Add dismissible tip for exiting the editor with the keyboard

### DIFF
--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -164,6 +164,26 @@ export default function PlaygroundPreview({
 	);
 	const [currentPostId, setCurrentPostId] = useState(0);
 
+	const dismissedExitWithKeyboardTipKey =
+		'playground-block-dismiss-exit-editor-tip';
+	const [dismissedExitWithKeyboardTip, setDismissedExitWithKeyboardTip] =
+		useState(localStorage[dismissedExitWithKeyboardTipKey] === 'true');
+	function dismissExitWithKeyboardTip() {
+		localStorage[dismissedExitWithKeyboardTipKey] = 'true';
+		setDismissedExitWithKeyboardTip(true);
+
+		// Shift focus to editor so focus is not lost as the tip disappears
+		if (codeMirrorRef?.current?.view?.dom) {
+			const contentEditableElement: HTMLElement =
+				codeMirrorRef.current.view.dom.querySelector(
+					'[contenteditable=true]'
+				);
+			if (contentEditableElement) {
+				contentEditableElement.focus();
+			}
+		}
+	}
+
 	/**
 	 * Let the parent component know when the state changes.
 	 */
@@ -529,6 +549,31 @@ export default function PlaygroundPreview({
 								<Icon icon={download} />
 							</Button>
 						</div>
+						{!dismissedExitWithKeyboardTip && (
+							<div>
+								<div
+									tabIndex={0}
+									className="playground-block-exit-editor-tip"
+									onClick={dismissExitWithKeyboardTip}
+								>
+									<span>
+										{createInterpolateElement(
+											// translators: This is a keyboard combination to exit the code editor.
+											__(
+												'Press <EscapeKey />, <TabKey /> to exit the editor.'
+											),
+											{
+												EscapeKey: <code>Esc</code>,
+												TabKey: <code>Tab</code>,
+											}
+										)}
+									</span>
+									<Button variant="link">
+										{__('Dismiss')}
+									</Button>
+								</div>
+							</div>
+						)}
 						<div className="code-editor-wrapper">
 							<ReactCodeMirror
 								ref={codeMirrorRef}

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -550,9 +550,8 @@ export default function PlaygroundPreview({
 							</Button>
 						</div>
 						{!dismissedExitWithKeyboardTip && (
-							<div
-								tabIndex={0}
-								role="button"
+							<button
+								type="button"
 								className="playground-block-exit-editor-tip"
 								onClick={dismissExitWithKeyboardTip}
 								onKeyDown={(event) => {
@@ -572,8 +571,10 @@ export default function PlaygroundPreview({
 										TabKey: <code>Tab</code>,
 									}
 								)}
-								<Button variant="link">{__('Dismiss')}</Button>
-							</div>
+								<a className="playground-block-exit-editor-tip-dismiss-link">
+									{__('Dismiss')}
+								</a>
+							</button>
 						)}
 						<div className="code-editor-wrapper">
 							<ReactCodeMirror

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -553,6 +553,7 @@ export default function PlaygroundPreview({
 							<div>
 								<div
 									tabIndex={0}
+									role="button"
 									className="playground-block-exit-editor-tip"
 									onClick={dismissExitWithKeyboardTip}
 									onKeyDown={(event) => {

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -550,33 +550,29 @@ export default function PlaygroundPreview({
 							</Button>
 						</div>
 						{!dismissedExitWithKeyboardTip && (
-							<div>
-								<div
-									tabIndex={0}
-									role="button"
-									className="playground-block-exit-editor-tip"
-									onClick={dismissExitWithKeyboardTip}
-									onKeyDown={(event) => {
-										if (event.key === 'Enter') {
-											event.preventDefault();
-											dismissExitWithKeyboardTip();
-										}
-									}}
-								>
-									{createInterpolateElement(
-										// translators: This is a keyboard combination to exit the code editor.
-										__(
-											'Press <EscapeKey />, <TabKey /> to exit the editor.'
-										),
-										{
-											EscapeKey: <code>Esc</code>,
-											TabKey: <code>Tab</code>,
-										}
-									)}
-									<Button variant="link">
-										{__('Dismiss')}
-									</Button>
-								</div>
+							<div
+								tabIndex={0}
+								role="button"
+								className="playground-block-exit-editor-tip"
+								onClick={dismissExitWithKeyboardTip}
+								onKeyDown={(event) => {
+									if (event.key === 'Enter') {
+										event.preventDefault();
+										dismissExitWithKeyboardTip();
+									}
+								}}
+							>
+								{createInterpolateElement(
+									// translators: This is a keyboard combination to exit the code editor.
+									__(
+										'Press <EscapeKey />, <TabKey /> to exit the editor.'
+									),
+									{
+										EscapeKey: <code>Esc</code>,
+										TabKey: <code>Tab</code>,
+									}
+								)}
+								<Button variant="link">{__('Dismiss')}</Button>
 							</div>
 						)}
 						<div className="code-editor-wrapper">

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -555,19 +555,23 @@ export default function PlaygroundPreview({
 									tabIndex={0}
 									className="playground-block-exit-editor-tip"
 									onClick={dismissExitWithKeyboardTip}
+									onKeyDown={(event) => {
+										if (event.key === 'Enter') {
+											event.preventDefault();
+											dismissExitWithKeyboardTip();
+										}
+									}}
 								>
-									<span>
-										{createInterpolateElement(
-											// translators: This is a keyboard combination to exit the code editor.
-											__(
-												'Press <EscapeKey />, <TabKey /> to exit the editor.'
-											),
-											{
-												EscapeKey: <code>Esc</code>,
-												TabKey: <code>Tab</code>,
-											}
-										)}
-									</span>
+									{createInterpolateElement(
+										// translators: This is a keyboard combination to exit the code editor.
+										__(
+											'Press <EscapeKey />, <TabKey /> to exit the editor.'
+										),
+										{
+											EscapeKey: <code>Esc</code>,
+											TabKey: <code>Tab</code>,
+										}
+									)}
 									<Button variant="link">
 										{__('Dismiss')}
 									</Button>

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -564,16 +564,38 @@ export default function PlaygroundPreview({
 								{createInterpolateElement(
 									// translators: This is a keyboard combination to exit the code editor.
 									__(
-										'Press <EscapeKey />, <TabKey /> to exit the editor.'
+										'Press <EscapeKey />, <TabKey /> to exit the editor. <DismissNotice />'
 									),
 									{
-										EscapeKey: <code>Esc</code>,
-										TabKey: <code>Tab</code>,
+										EscapeKey: (
+											<code
+												aria-label={
+													// translators: The keyboard's Escape key
+													__('Escape key')
+												}
+											>
+												Esc
+											</code>
+										),
+										TabKey: (
+											<code
+												aria-label={
+													// translators: The keyboard's Tab key
+													__('Tab key')
+												}
+											>
+												Tab
+											</code>
+										),
+										DismissNotice: (
+											<span className="playground-block-exit-editor-tip-dismiss-notice">
+												{__(
+													'(Click to dismiss this notice.)'
+												)}
+											</span>
+										),
 									}
 								)}
-								<a className="playground-block-exit-editor-tip-dismiss-link">
-									{__('Dismiss')}
-								</a>
 							</button>
 						)}
 						<div className="code-editor-wrapper">

--- a/packages/wordpress-playground-block/src/style.scss
+++ b/packages/wordpress-playground-block/src/style.scss
@@ -383,4 +383,34 @@
 		background-color: #0c0224;
 		color: #fff;
 	}
+
+	.playground-block-exit-editor-tip {
+		cursor: pointer;
+		background: #fff7cc;
+		padding: 7px 13px;
+
+		&:focus {
+			// Avoid outline on click
+			outline: 0;
+		}
+		&:focus-visible {
+			outline: auto;
+			// Avoid completely clipped outline
+			outline-offset: -2px;
+		}
+
+		code {
+			// TODO: Is there a good WordPress CSS var for monospace font?
+			font-family: monospace;
+			border: 1px solid #00000077;
+			border-radius: 5px;
+			padding: 2px 4px;
+			margin: 0px 1px;
+		}
+
+		button {
+			margin-inline-start: 7px;
+			font-size: inherit;
+		}
+	}
 }

--- a/packages/wordpress-playground-block/src/style.scss
+++ b/packages/wordpress-playground-block/src/style.scss
@@ -386,8 +386,11 @@
 
 	.playground-block-exit-editor-tip {
 		cursor: pointer;
+		border: 0;
 		background: #fff7cc;
-		padding: 7px 13px;
+		padding: 11px;
+		font-size: inherit;
+		text-align: left;
 
 		&:focus {
 			// Avoid outline on click
@@ -408,9 +411,8 @@
 			margin: 0px 1px;
 		}
 
-		button {
+		.playground-block-exit-editor-tip-dismiss-link {
 			margin-inline-start: 7px;
-			font-size: inherit;
 		}
 	}
 }

--- a/packages/wordpress-playground-block/src/style.scss
+++ b/packages/wordpress-playground-block/src/style.scss
@@ -410,9 +410,5 @@
 			padding: 2px 4px;
 			margin: 0px 1px;
 		}
-
-		.playground-block-exit-editor-tip-dismiss-link {
-			margin-inline-start: 7px;
-		}
 	}
 }


### PR DESCRIPTION
## What?

This PR adds a dismissible tip at the top of the editor to help keyboard-centric users know how they can leave the editor once it is focused.

Related to #316 

## Why?

As @joedolson [said](https://github.com/WordPress/playground-tools/issues/316):
"Having a visible text explanation would significantly improve the accessibility of the code view for keyboard users."

## Testing Instructions

- Run `npx nx dev wordpress-playground-block`
- View a post that has the Playground block
- Note the notice at the top of the editor
- Click "Dismiss" to dismiss the notice
- Confirm the notice is hidden
- Refresh the page and confirm the notice is no longer shown

To repeat this, open the dev tools and delete the key "playground-block-dismiss-exit-editor-tip".
