### PR TITLE
Playground block: Stop making readonly code actually readonly in editor

### DIFF
--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -541,7 +541,7 @@ export default function PlaygroundPreview({
 									),
 								]}
 								readOnly={
-									codeEditorReadOnly ||
+									(codeEditorReadOnly && !inBlockEditor) ||
 									isErrorLogFile(files[activeFileIndex])
 								}
 								onChange={(value) =>


### PR DESCRIPTION
## What?

When the Playground block is marked as readonly, it was preventing editing of code files in the block editor. The correct behavior for "Code editor is read only" is to allow editing in the editor but not on the front end.

## Testing Instructions

- Edit post containing Playground block
- Enable "Code editor is read only" for the block
- Confirm that the code file can still be edited in the editor
- Publish and confirm that the code files in the block cannot be edited on the front end
