### PR TITLE
Playground block: fix vertical code editor height in Safari

### DIFF
--- a/packages/wordpress-playground-block/src/style.scss
+++ b/packages/wordpress-playground-block/src/style.scss
@@ -146,7 +146,7 @@
 
 			.cm-editor {
 				width: 100%;
-				height: 100%;
+				height: auto;
 				max-height: min(450px, 80vh);
 			}
 		}


### PR DESCRIPTION
## What?

This PR fixes a style bug with the Playground block code editor in Safari.

Before this PR, the code editor rendered with insufficient height in Safari:
![Screenshot 2024-07-30 at 5 18 25 PM](https://github.com/user-attachments/assets/1f33d39d-cef7-422c-b666-e6255f7cca07)

After this PR, the code editor renders with sufficient height in Safari:
![Screenshot 2024-07-30 at 5 18 38 PM](https://github.com/user-attachments/assets/67065895-7be4-4782-8ecd-5c6bfa292d8c)

## How?

By changing the `.cm-editor` height from
`height: 100%;`
to
`height: auto;`

This change has been tested successfully in Safari, Firefox, and Chrome on macOS.

## Testing Instructions

- Create a post with the block in vertical layout
- View post in Safari
- Confirm that the editor takes up all vertical space between the files tabs and the bottom bar containing the "Run" button