### PR TITLE
Playground block: Fix visual tab order of open-in-new-tab button

### DIFF
--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -433,26 +433,6 @@ export default function PlaygroundPreview({
 			aria-label={__('WordPress Playground')}
 			className={mainContainerClass}
 		>
-			<header className="wordpress-playground-header">
-				{!inBlockEditor && !inFullPageView && (
-					<Button
-						variant="link"
-						className="wordpress-playground-header__full-page-link"
-						onClick={() => {
-							window.open(getFullPageUrl(), '_blank');
-						}}
-						aria-label={
-							// Add dedicated aria-label for screen readers
-							// because an arrow is added to the main button
-							// label via CSS pseudo-element, and our users with
-							// screen readers do not need an arrow read to them.
-							__('Open in New Tab')
-						}
-					>
-						{__('Open in New Tab')}
-					</Button>
-				)}
-			</header>
 			<div className={contentContainerClass}>
 				{codeEditor && (
 					<div className="code-container">
@@ -789,7 +769,7 @@ export default function PlaygroundPreview({
 			<footer className="wordpress-playground-footer">
 				<a
 					href="https://w.org/playground"
-					className="wordpress-playground-footer__link"
+					className="wordpress-playground-footer__powered_by_link"
 					target="_blank"
 					aria-label={
 						// Provide dedicated ARIA label because NVDA does not
@@ -807,7 +787,7 @@ export default function PlaygroundPreview({
 						),
 						{
 							span1: (
-								<span className="wordpress-playground-footer__powered" />
+								<span className="wordpress-playground-footer__powered_text" />
 							),
 							WordPressIcon: (
 								<>
@@ -826,11 +806,29 @@ export default function PlaygroundPreview({
 								</>
 							),
 							span2: (
-								<span className="wordpress-playground-footer__link-text" />
+								<span className="wordpress-playground-footer__powered_by_link-text" />
 							),
 						}
 					)}
 				</a>
+				{!inBlockEditor && !inFullPageView && (
+					<Button
+						variant="link"
+						className="wordpress-playground-footer__full-page-link"
+						onClick={() => {
+							window.open(getFullPageUrl(), '_blank');
+						}}
+						aria-label={
+							// Add dedicated aria-label for screen readers
+							// because an arrow is added to the main button
+							// label via CSS pseudo-element, and our users with
+							// screen readers do not need an arrow read to them.
+							__('Open in New Tab')
+						}
+					>
+						{__('Open in New Tab')}
+					</Button>
+				)}
 			</footer>
 		</section>
 	);

--- a/packages/wordpress-playground-block/src/style.scss
+++ b/packages/wordpress-playground-block/src/style.scss
@@ -41,27 +41,8 @@
 		justify-content: center;
 		align-items: center;
 
-		// Let's be explicit about flex item order
-		.wordpress-playground-content-container {
-			order: 0;
-		}
-		.wordpress-playground-footer {
-			order: 1;
-		}
-		.wordpress-playground-header {
-			// For accessibility purposes, we want the header to contain
-			// the open-in-new-tab button, but for layout, we want the
-			// button to appear next to the powered-by footer. So we use
-			// flexbox item ordering to achieve this.
-			order: 2;
-		}
-
 		.wordpress-playground-content-container {
 			width: 100%;
-		}
-		.wordpress-playground-header {
-			text-align: start;
-			margin-inline-start: 11px;
 		}
 		.wordpress-playground-footer {
 			text-align: end;
@@ -158,7 +139,7 @@
 		flex-direction: column;
 		flex-wrap: nowrap;
 
-		.wordpress-playground-header {
+		.wordpress-playground-footer__full-page-link {
 			display: none;
 		}
 
@@ -184,16 +165,10 @@
 		}
 	}
 
-	$header-footer-spacing: 4px;
-
-	.wordpress-playground-header,
-	.wordpress-playground-footer {
-		padding: $header-footer-spacing 2 * $header-footer-spacing;
-	}
-
-	.wordpress-playground-header__full-page-link {
+	.wordpress-playground-footer__full-page-link {
 		text-decoration: none;
 		font-size: 13px;
+		margin-inline-start: 11px;
 
 		$northeast-arrow: '\002197';
 		$northwest-arrow: '\002196';
@@ -209,20 +184,28 @@
 	}
 
 	.wordpress-playground-footer {
+		$link-spacing: 4px;
+
+		.wordpress-playground-footer__powered_by_link,
+		.wordpress-playground-footer__full-page-link {
+			padding: $link-spacing 2 * $link-spacing;
+		}
+
 		$color: var(--wp--preset--color--contrast);
 		$hover-color: var(--wp--preset--color--vivid-cyan-blue);
-		.wordpress-playground-footer__link,
-		.wordpress-playground-footer__powered,
-		.wordpress-playground-footer__link-text {
+
+		.wordpress-playground-footer__powered_by_link,
+		.wordpress-playground-footer__powered_text,
+		.wordpress-playground-footer__powered_by_link-text {
 			color: $color;
 			text-decoration: none;
 			font-size: 13px;
 			display: inline-block;
 		}
-		.wordpress-playground-footer__powered {
+		.wordpress-playground-footer__powered_text {
 			opacity: 0.7;
 		}
-		.wordpress-playground-footer__link {
+		.wordpress-playground-footer__powered_by_link {
 			.wordpress-playground-footer__spacing {
 				display: inline-block;
 				width: 0;
@@ -234,8 +217,8 @@
 				vertical-align: middle;
 			}
 			&:hover {
-				.wordpress-playground-footer__link-text,
-				.wordpress-playground-footer__powered {
+				.wordpress-playground-footer__powered_by_link-text,
+				.wordpress-playground-footer__powered_text {
 					color: $hover-color;
 					opacity: 1;
 				}

--- a/packages/wordpress-playground-block/src/style.scss
+++ b/packages/wordpress-playground-block/src/style.scss
@@ -184,11 +184,15 @@
 	}
 
 	.wordpress-playground-footer {
-		$link-spacing: 4px;
+		margin: 4px;
 
 		.wordpress-playground-footer__powered_by_link,
 		.wordpress-playground-footer__full-page-link {
-			padding: $link-spacing 2 * $link-spacing;
+			margin: 0 8px;
+		}
+
+		.wordpress-playground-footer__full-page-link {
+			margin-inline-start: 19px;
 		}
 
 		$color: var(--wp--preset--color--contrast);


### PR DESCRIPTION
## What, why, and how?

The open-in-new-tab button is visually positioned in the block footer, but in the markup, it was originally placed in the section header so the link would be the first thing focused by those using assistive technologies. Unfortunately, that leads to a confusing visual tab order because a link in the block footer is focused first, followed by everything else.

This PR places the open-in-new-tab button in the footer, so the tab order matches the intuitive visual order.

Fixes #344

## Testing Instructions

- Run `npx nx dev wordpress-playground-block`
- View a post with a Playground block
- Confirm that the button remains in the footer with a reasonable location and spacing
- Click on the button to open the block in a full window
- Confirm that the open-in-new-tab button is hidden in the full window view