### PR TITLE
[Interactive code block] Add "theme mode" in the code editor

### DIFF
--- a/packages/wordpress-playground-block/src/components/playground-preview/download-zipped-package.ts
+++ b/packages/wordpress-playground-block/src/components/playground-preview/download-zipped-package.ts
@@ -4,7 +4,10 @@ import {
 	// @ts-ignore
 } from 'https://playground.wordpress.net/client/index.js';
 
-export default async function downloadZippedPackage(client: PlaygroundClient, codeEditorMode) {
+export default async function downloadZippedPackage(
+	client: PlaygroundClient,
+	codeEditorMode
+) {
 	const docroot = await client.documentRoot;
 
 	let pluginPath = docroot + '/wp-content/plugins/demo-plugin';

--- a/packages/wordpress-playground-block/src/components/playground-preview/download-zipped-package.ts
+++ b/packages/wordpress-playground-block/src/components/playground-preview/download-zipped-package.ts
@@ -4,12 +4,20 @@ import {
 	// @ts-ignore
 } from 'https://playground.wordpress.net/client/index.js';
 
-export default async function downloadZippedPlugin(client: PlaygroundClient) {
+export default async function downloadZippedPackage(client: PlaygroundClient, codeEditorMode) {
 	const docroot = await client.documentRoot;
-	const pluginPath = docroot + '/wp-content/plugins/demo-plugin';
+
+	let pluginPath = docroot + '/wp-content/plugins/demo-plugin';
+	let fileName = 'wordpress-playground-plugin.zip';
+
+	if (codeEditorMode == 'theme') {
+		pluginPath = docroot + '/wp-content/themes/demo-theme';
+		fileName = 'wordpress-playground-theme.zip';
+	}
+
 	const zipFile = new File(
 		[await zipPlaygroundFiles(client, pluginPath)],
-		'wordpress-playground-plugin.zip',
+		fileName,
 		{
 			type: 'application/zip',
 		}

--- a/packages/wordpress-playground-block/src/components/playground-preview/write-theme-files.ts
+++ b/packages/wordpress-playground-block/src/components/playground-preview/write-theme-files.ts
@@ -10,10 +10,10 @@ export const writeThemeFiles = async (
 	files: EditorFile[]
 ) => {
 	const docroot = await client.documentRoot;
-	const themeSlug = 'demo-theme';
-	console.log('themeSlug', themeSlug);
+	const themeFolderName = 'demo-theme';
+	console.log('themeSlug', themeFolderName);
 
-	const themePath = docroot + '/wp-content/themes/' + themeSlug;
+	const themePath = docroot + '/wp-content/themes/' + themeFolderName;
 	if (await client.fileExists(themePath)) {
 		await client.rmdir(themePath, {
 			recursive: true,
@@ -30,7 +30,7 @@ export const writeThemeFiles = async (
 
 	try {
 		await activateTheme(client, {
-			themeSlug,
+			themeFolderName,
 		});
 	} catch (e) {
 		console.error(e);

--- a/packages/wordpress-playground-block/src/components/playground-preview/write-theme-files.ts
+++ b/packages/wordpress-playground-block/src/components/playground-preview/write-theme-files.ts
@@ -11,8 +11,6 @@ export const writeThemeFiles = async (
 ) => {
 	const docroot = await client.documentRoot;
 	const themeFolderName = 'demo-theme';
-	console.log('themeSlug', themeFolderName);
-
 	const themePath = docroot + '/wp-content/themes/' + themeFolderName;
 	if (await client.fileExists(themePath)) {
 		await client.rmdir(themePath, {

--- a/packages/wordpress-playground-block/src/components/playground-preview/write-theme-files.ts
+++ b/packages/wordpress-playground-block/src/components/playground-preview/write-theme-files.ts
@@ -1,0 +1,38 @@
+import type { EditorFile } from '../../index';
+import {
+	PlaygroundClient,
+	activateTheme,
+	// @ts-ignore
+} from 'https://playground.wordpress.net/client/index.js';
+
+export const writeThemeFiles = async (
+	client: PlaygroundClient,
+	files: EditorFile[]
+) => {
+	const docroot = await client.documentRoot;
+	const themeSlug = 'demo-theme';
+	console.log('themeSlug', themeSlug);
+
+	const themePath = docroot + '/wp-content/themes/' + themeSlug;
+	if (await client.fileExists(themePath)) {
+		await client.rmdir(themePath, {
+			recursive: true,
+		});
+	}
+	await client.mkdir(themePath);
+
+	for (const file of files) {
+		const filePath = `${themePath}/${file.name}`;
+		const parentDir = filePath.split('/').slice(0, -1).join('/');
+		await client.mkdir(parentDir);
+		await client.writeFile(filePath, file.contents);
+	}
+
+	try {
+		await activateTheme(client, {
+			themeSlug,
+		});
+	} catch (e) {
+		console.error(e);
+	}
+};

--- a/packages/wordpress-playground-block/src/edit.tsx
+++ b/packages/wordpress-playground-block/src/edit.tsx
@@ -272,7 +272,7 @@ export default withBase64Attrs(function Edit({
 								@see https://github.com/WordPress/playground-tools/issues/196
 								@todo Before re-enabling, add i18n support.
 								*/}
-								<div style={{ display: 'none' }}>
+								<div>
 									<SelectControl
 										help={
 											<div>
@@ -290,6 +290,18 @@ export default withBase64Attrs(function Edit({
 														the Playground.
 													</li>
 													<li>
+														<strong>Theme</strong>:
+														all the files will be
+														placed in a separate
+														theme which will be
+														automatically enabled in
+														the Playground.
+													</li>
+													<li
+														style={{
+															display: 'none',
+														}}
+													>
 														<strong>
 															Editor script
 														</strong>
@@ -320,12 +332,12 @@ export default withBase64Attrs(function Edit({
 												value: '',
 											},
 											{
-												label: 'Editor script',
-												value: 'editor-script',
-											},
-											{
 												label: 'Plugin',
 												value: 'plugin',
+											},
+											{
+												label: 'Theme',
+												value: 'theme',
 											},
 										]}
 										value={codeEditorMode}

--- a/packages/wordpress-playground-block/src/edit.tsx
+++ b/packages/wordpress-playground-block/src/edit.tsx
@@ -6,6 +6,7 @@ import { useState, useRef } from '@wordpress/element';
 import {
 	ToggleControl,
 	SelectControl,
+	RadioControl,
 	TextareaControl,
 	Panel,
 	PanelBody,
@@ -143,6 +144,8 @@ export default withBase64Attrs(function Edit({
 		requireLivePreviewActivation,
 	} = attributes;
 
+	const showJSXTranspileOption = codeEditorMode === 'plugin';
+
 	return (
 		<div {...useBlockProps()}>
 			<PlaygroundPreview
@@ -222,21 +225,43 @@ export default withBase64Attrs(function Edit({
 										});
 									}}
 								/>
-								<ToggleControl
-									label={__('Transpile JSX to JS')}
-									help={__(
-										`Transpiles JSX syntax to JS using esbuild. Only the JSX tags are ` +
-											`transpiled. Imports and other advanced ES module syntax features are ` +
-											`preserved.`
-									)}
-									checked={codeEditorTranspileJsx}
-									onChange={() => {
-										setAttributes({
-											codeEditorTranspileJsx:
-												!codeEditorTranspileJsx,
-										});
+								<RadioControl
+									label="Code editor mode"
+									selected={codeEditorMode}
+									options={[
+										{ label: 'Plugin', value: 'plugin' },
+										{ label: 'Theme', value: 'theme' },
+									]}
+									onChange={(value) => {
+										if (value === 'theme') {
+											setAttributes({
+												codeEditorMode: value,
+												codeEditorTranspileJsx: false,
+											});
+										} else {
+											setAttributes({
+												codeEditorMode: value,
+											});
+										}
 									}}
 								/>
+								{showJSXTranspileOption && (
+									<ToggleControl
+										label={__('Transpile JSX to JS')}
+										help={__(
+											`Transpiles JSX syntax to JS using esbuild. Only the JSX tags are ` +
+												`transpiled. Imports and other advanced ES module syntax features are ` +
+												`preserved.`
+										)}
+										checked={codeEditorTranspileJsx}
+										onChange={() => {
+											setAttributes({
+												codeEditorTranspileJsx:
+													!codeEditorTranspileJsx,
+											});
+										}}
+									/>
+								)}
 								<ToggleControl
 									label={__('Multiple files')}
 									help={
@@ -272,7 +297,7 @@ export default withBase64Attrs(function Edit({
 								@see https://github.com/WordPress/playground-tools/issues/196
 								@todo Before re-enabling, add i18n support.
 								*/}
-								<div>
+								<div style={{ display: 'none' }}>
 									<SelectControl
 										help={
 											<div>
@@ -290,18 +315,6 @@ export default withBase64Attrs(function Edit({
 														the Playground.
 													</li>
 													<li>
-														<strong>Theme</strong>:
-														all the files will be
-														placed in a separate
-														theme which will be
-														automatically enabled in
-														the Playground.
-													</li>
-													<li
-														style={{
-															display: 'none',
-														}}
-													>
 														<strong>
 															Editor script
 														</strong>
@@ -332,12 +345,12 @@ export default withBase64Attrs(function Edit({
 												value: '',
 											},
 											{
-												label: 'Plugin',
-												value: 'plugin',
+												label: 'Editor script',
+												value: 'editor-script',
 											},
 											{
-												label: 'Theme',
-												value: 'theme',
+												label: 'Plugin',
+												value: 'plugin',
 											},
 										]}
 										value={codeEditorMode}


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->

This PR attempts to add theme support to the code editor mode, so that users can set up a plugin or theme in the code editor mode. 

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I would like to be able to set up practical activities for learners on Learn.WordPress.org around both plugin and theme development, using the WordPress Playground block

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->

1. Check out the [jonathanbossenger:351-code-editor-theme-support](https://github.com/jonathanbossenger/playground-tools/tree/351-code-editor-theme-support) branch
2. Load and instance of the playground in the Site Editor
3. Change the Code Editor Mode to "Theme"
4. Create a style.css and templates/index.html block theme files
5. Run the playground preview
6. The two theme files should activate as the active theme in the preview

Fixes #351 