### PR TITLE
Update contributing instructions to include wp-now installation

### DIFF
--- a/packages/wordpress-playground-block/README.md
+++ b/packages/wordpress-playground-block/README.md
@@ -64,6 +64,7 @@ In order to contribute to `wordpress-playground-block`, you'll need to first ins
 
 -   Make sure you have `nvm` installed. If you need to install it first,
     [follow these installation instructions](https://github.com/nvm-sh/nvm#installation).
+-   Install wp-now globally to power the local development environment by running `npm install -g @wp-now/wp-now`    
 -   Install `nx` by running `npm install -g nx`.
 
 Once the global dependencies are installed, you can start using the repo:


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

Adds a step to install wp-now globally, which powers the local development environment for contributing to the playground block.

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->

## Why?

In setting up the local development environment for the playground block, I discovered I needed wp-now installed.

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->