### PR TITLE
Playground block: Reflect preview loading status for screen readers

### DIFF
--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -199,7 +199,11 @@ function PlaygroundPreview({
 	}, [playgroundClientRef.current, currentPostId, files]);
 
 	useEffect(() => {
-		speak('WordPress Playground loaded.', 'polite');
+		speak(
+			// translators: This says that the Playground preview has loaded.
+			__('WordPress Playground loaded.'),
+			'polite'
+		);
 	}, [playgroundClientRef.current]);
 
 	const currentFileExtension = activeFile?.name.split('.').pop();

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -198,14 +198,6 @@ function PlaygroundPreview({
 		});
 	}, [playgroundClientRef.current, currentPostId, files]);
 
-	useEffect(() => {
-		speak(
-			// translators: This says that the Playground preview has loaded.
-			__('WordPress Playground loaded.'),
-			'polite'
-		);
-	}, [playgroundClientRef.current]);
-
 	const currentFileExtension = activeFile?.name.split('.').pop();
 
 	useEffect(() => {
@@ -269,6 +261,21 @@ function PlaygroundPreview({
 
 			await client.isReady();
 			playgroundClientRef.current = client;
+
+			// Hack: Delay the announcement to give iframe loading percentage
+			// announcements for the iframe a chance to be queued before this
+			// "loading complete" announcement. Without this, macOS VoiceOver
+			// often speaks "WordPress Playground loaded. 10% loaded" which
+			// is a miscommunication because Playground has already loaded.
+			setTimeout(
+				() =>
+					speak(
+						// translators: This says that the Playground preview has loaded.
+						__('WordPress Playground loaded.'),
+						'polite'
+					),
+				500
+			);
 
 			await reinstallEditedPlugin();
 

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -198,6 +198,10 @@ function PlaygroundPreview({
 		});
 	}, [playgroundClientRef.current, currentPostId, files]);
 
+	useEffect(() => {
+		speak('WordPress Playground loaded.', 'polite');
+	}, [playgroundClientRef.current]);
+
 	const currentFileExtension = activeFile?.name.split('.').pop();
 
 	useEffect(() => {

--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -435,6 +435,19 @@ function PlaygroundPreview({
 			'WordPress website which may be a challenge for screen readers.'
 	);
 
+	const activeStatusLabel = playgroundClientRef.current
+		? // translators: State of the playground iframe after it has loaded.
+		  __('Loaded')
+		: // translators: State of the playground iframe while it is loading.
+		  __('Loading');
+	// translators: State of the playground iframe before the user activates it.
+	const inactivateStatusLabel = __('Not Activated');
+	const beforePlaygroundPreviewLabel = sprintf(
+		// translators: %s: status of the Playground preview
+		__('Beginning of Playground Preview - %s'),
+		isLivePreviewActivated ? activeStatusLabel : inactivateStatusLabel
+	);
+
 	return (
 		<section
 			aria-label={__('WordPress Playground')}
@@ -684,10 +697,7 @@ function PlaygroundPreview({
 								tabIndex={-1}
 								ref={beforePreviewRef}
 							>
-								{
-									// translators: screen reader text noting beginning of the playground iframe
-									__('Beginning of Playground Preview')
-								}
+								{beforePlaygroundPreviewLabel}
 							</span>
 							<a
 								href="#"

--- a/packages/wordpress-playground-block/src/style.scss
+++ b/packages/wordpress-playground-block/src/style.scss
@@ -121,7 +121,7 @@
 			}
 			.playground-container {
 				width: 100%;
-				height: 400px;
+				height: 500px;
 				flex-basis: 500px;
 			}
 


### PR DESCRIPTION
## What and why?

This PR adds a couple of measures to communicate Playground preview loading status:
- Updating the before-preview marker to say one of the following depending on state:
  - "Beginning of Playground Preview - Not activated"
  - "Beginning of Playground Preview - Loading"
  - "Beginning of Playground Preview - Loaded"
- Speaking "WordPress Playground loaded" after Playground completes loading

Related to #290 

## Why?

We received a11y feedback that the preview loading status is not clearly communicated.

## Testing Instructions

- Start a screen reader
- View a post containing a Playground block that requires activation
- Click the Activate button
- Observe that the before-preview marker is focused and that its text updates in response to preview loading status
- Observe that "WordPress Playground loaded" is spoken once the preview completes loading
