### PR TITLE
fix vscode-extension bundle step adding correct jspi subfolder

### DIFF
--- a/packages/vscode-extension/project.json
+++ b/packages/vscode-extension/project.json
@@ -46,8 +46,8 @@
 					"cp ./LICENSE dist/packages/vscode-extension",
 					"cp packages/vscode-extension/package.json dist/packages/vscode-extension",
 					"cp packages/vscode-extension/README.md dist/packages/vscode-extension",
-					"cp -r node_modules/@php-wasm/node/7_* dist/packages/vscode-extension",
-					"cp -r node_modules/@php-wasm/node/8_* dist/packages/vscode-extension"
+					"cp -r node_modules/@php-wasm/node/jspi/7_* dist/packages/vscode-extension",
+					"cp -r node_modules/@php-wasm/node/jspi/8_* dist/packages/vscode-extension"
 				],
 				"parallel": false
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground Tools! -->

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->

It updates the correct path of `jspi/PHP_*` to be included in the VS Code extension after upgrading the Playground dependencies on https://github.com/WordPress/playground-tools/pull/350

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The paths to wasm files have changed in the new version.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Updating the project bundle step.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->

* Run `npx nx run vscode-extension:build:bundle`
* Observe the command finishes successfully : ` >  NX   Successfully ran target build:bundle for project vscode-extension (501ms)`



