### PR TITLE
Update README.md to correct typo in extension path

### DIFF
--- a/packages/edit-visually-browser-extension/README.md
+++ b/packages/edit-visually-browser-extension/README.md
@@ -2,7 +2,7 @@
 
 This is an experimental browser extension that allows you to edit GitHub issues and other text formats using WordPress blocks in Playground.
 
-To use it, go to the extensions page in your web browser, load the extension from the `packages/editor-browser-extension` directory, and then navigate to any GitHub issue. Edit it, and you should see a new "Edit in Playground" button in the corner of the editor. Click it to edit the issue in Playground.
+To use it, go to the extensions page in your web browser, load the extension from the `packages/edit-visually-browser-extension` directory, and then navigate to any GitHub issue. Edit it, and you should see a new "Edit in Playground" button in the corner of the editor. Click it to edit the issue in Playground.
 
 Another use-case here: replying to people. It’s frustrating to keep scrolling between what someone posted and the textarea where I can type, but with this extension we could front-load what they said to the editor, package it as quotes, and it would be easy to break it up and type.
 


### PR DESCRIPTION
## What?

Updating path in readme to match actual path in repo

## Why?

Typo in readme that didn't match actual path to code

## Testing Instructions

1. Set up the extension on chrome browser following the corrected instructions
2. verify that the UI in Github is now visible

![CleanShot 2024-10-24 at 10 15 50](https://github.com/user-attachments/assets/1f401eeb-9ca9-431a-b1e0-27e61f675038)

