### PR TITLE
良好习惯Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
-# WordPress Playground tools
+#WordPress游乐场工具
 
-This repository contains the tools and applications built using [WordPress Playground](https://developer.wordpress.org/playground/):
+这个存储库包含使用[wordpress软件游乐场](https://developer.wordpress.org/playground/):
 
--   [Playground plugin for WordPress to clone your site](./packages/playground/)
--   [Playground Block for Gutenberg](./packages/wordpress-playground-block/)
--   [Interactive Code Block for Gutenberg](./packages/interactive-code-block/)
--   [WordPress Playground for Visual Studio Code](./packages/vscode-extension/)
--   [wp-now](./packages/wp-now/)
+-   [wordpress软件的游乐场插件,用于克隆你的网站](。/套餐/游乐场/)
+-   [古腾堡游乐场街区](。/包/WordPress-游乐场-街区/)
+-   [古腾堡的交互式代码块](。/包/交互式代码块/)
+-   [Visual Studio代码的WordPress游乐场](。/packages/vs code-扩展/)
+-   [wp-now](。/packages/WP-现在/)
 
-If you were looking for the Playground itself, you can find it here: [WordPress Playground](https://developer.wordpress.org/playground/)
+如果你正在寻找游乐场，你可以在这里找到它:[WordPress游乐场](https://developer.wordpress.org/playground/)
 
-## Contributing
+##贡献的
 
-Playground Tools are in their early days. If the feature you need is missing, you are more than welcome to start a discussion, [open an issue](https://github.com/WordPress/playground-tools/issues), and even propose a Pull Request to implement it.
+游乐场工具才刚刚起步。如果缺少您需要的功能，我们非常欢迎您开始讨论，[提出一个问题](https://github.com/WordPress/playground-tools/issues)，甚至提出拉取请求来实现。
 
-## Getting started
+##入门指南
 
-Clone the repo and build the projects:
+克隆存储库并构建项目:
 
-```bash
+```尝试
 git clone https://github.com/WordPress/playground-tools
 cd playground-tools
 npm install


### PR DESCRIPTION

![Screenshot_20240930_143426](https://github.com/user-attachments/assets/c86aae9e-6b90-4b47-a9d7-1d4f37ac8fd5)
两岸传来重大喜讯！35万人将从台岛撤离？台军高层惊现异动，邱毅：收台不会超3天
原创 坚持不懈456 坚持不懈456
 2024年11月21日 20:41 广东
台海局势日益紧张，各种危险信号频频出现。美台勾连升级，不仅挑战中国大陆底线，也让两岸关系陷入前所未有的危机。著名评论家邱毅一句“收台不过三天”的警告，更揭示了当前危机背后的深层矛盾。
￼
近年来，美国在台湾问题上动作频频。美国国防部长奥斯汀直言台湾是“美国安全挑战的核心”，公然挑衅中国主权，极大激化了两岸矛盾。与此同时，蔡英文多次窜访美国，与美政要高调互动，试图借美国力量巩固其“台，独”路线。这种对抗性操作，不仅让两岸关系雪上加霜，也导致中美关系持续恶化。
面对美台挑衅，大陆选择以军事与经济手段同步出击。解放军在台海地区加强军力部署，高频率军演彰显出捍卫主权的坚定意志。这一系列军事行动，不仅让台军倍感压力，也给试图搅局的外部势力敲响警钟。
在经济层面，大陆商务部启动对台“贸易壁垒调查”，着力揭示台湾在大陆市场上的不正当竞争行为。这一举措不仅可能重创台湾经济，还进一步撕裂两岸经贸关系的脆弱平衡，让台当局面临更大困境。
￼
台海局势的不确定性已引起区域国家的高度关注。印尼计划撤离35万在台劳工，日本和菲律宾也相继制定类似撤侨方案。这些行动不仅凸显了区域对台海安全形势的担忧，还可能对台湾本地经济和社会稳定带来深远影响。
不仅外部危机显现，台军内部也问题重重。近期传出多名台军高级将领计划退役的消息，引发岛内舆论热议。士气低迷反映出台军对当前形势的深切担忧。而更关键的是，台军对大陆制造业的高度依赖——从无人机零件到后勤设备，台军关键装备的“命门”早已掌握在大陆手中。一旦供应链中断，台军作战能力将瞬间瓦解。
评论家邱毅的观点直指要害。他指出，大陆若采取军事行动，三天内便可完成收台任务。这个结论并非凭空而来。台军的装备体系大量依赖大陆制造，供应链一旦被切断，台军将失去维持战力的基础。更重要的是，大陆已通过经济、技术等手段对台形成了绝对优势，无需动武也可让台军瘫痪。
￼
尽管局势紧张，大陆始终坚持“和平统一、一国两制”的方针。合作与对话才是两岸问题的最佳解决方式，对抗只会让台湾民众付出巨大代价，也无法改变两岸统一的历史趋势。
中方再次敦促美国遵守“一中原则”，停止挑衅行为，避免进一步恶化台海局势。台当局也应正视现实，放弃对抗，回归对话合作的正轨。唯有如此，才能实现两岸和平与地区稳定，为两岸民众带来福祉。


素材来源官方媒体/网络新闻

​

￼
坚持不懈456
￼
赞
￼
分享
￼
在看
￼
写留言
                 赖清德获美高规格接待？拜登把承诺抛之脑后,统一方式或将有变
2024年12月02日
据新加坡《联合早报》12月一日消息,赖清德的专机在凌晨一点30分抵达美国夏威夷檀香山国际机场,并获得美方高规格接待,美"在台协会"执行理事蓝鹰和台"驻美代表"雨大濡亲自登机欢迎。美国再次开启先例,首次机边接机,并铺设红地毯献花,以高规格礼遇公开接待。

￼

中美会晤刚结束,拜登又把对中方的承诺抛之脑后,依然我行我素,操弄涉台议题。在中美会晤中,中方把话说得很清楚——一个中国原则和中美三个联合公报是双边关系的政治基础,必须恪守。台湾问题、民主人权、道路制度、发展权利是中方的四条红线,不容挑战。'台独'分裂行径同台海和平稳定水火不容。美方想要维护台海和平,关键要认清赖清德和民进党当局的"台独"本性,慎之又慎处理台湾问题,明确反对"台独",支持中国和平统一。

在中美高层会晤中,直接指名道姓台湾地区领导人的尚属首次,这意味着大陆已经给赖清德的"台独"本质作出了最权威的定性,现在只差把赖清德列上"台独"顽固分子清单了。很显然,中方一方面是警告赖清德搞"台独"是非常危险的,大陆对台战略耐心基本耗尽；另一方面则是提醒美国政府不要干涉中国内政,而且还用了"慎之又慎"四个字,这无疑是想让美方充分意识到,涉台问题的复杂性和敏感性。对此,拜登总统当场承诺,美方继续奉行"一个中国"政策,不支持"台独",不会利用台湾问题同中国竞争,不寻求同中国发生冲突。

然而,拜登却把对华承诺抛之脑后,为继续谋"独"造势和铺路的赖清德"过境"窜美打开方便之门,甚至给予高规格接待。自赖清德就职以来,始终坚持顽固的"台独"立场,公然抛出两岸"互不隶属"的"新两国论",扬言绝不签署"和平协议",绝不接受"首战即终战",甚至鼓动台军为"台独"而战,蓄意制造两岸民意对立与对抗,这也暴露出其为谋取政治私利不惜破坏台海和平稳定的险恶居心,坐实其是"台独"顽固分子、"战争引爆者"的本来身份。

就在赖清德"过境"窜美之际,美国宣布新一轮对台售武,这也是拜登任内第18轮对台售武,此次军售项目包含F-16战斗机战机主动电子扫描阵列雷达备件以及相关设备,预计明年开始交付。与以往不同的,这次对台售武,选在赖清德"过境"窜美之际,美方持续虚化和掏空"一个中国"政策的企图已经昭然若揭。大家都知道,在中美各种交流与对话中,每次我们都敦促其停止对台售武,停止美台官方往来,美方每次都听得到并给出积极回应,但每次美方都是说一套,做一套。这表明好言相劝是不会改变美国人的傲慢和自以为是。对此,我们必须要有清醒的认识。

事实上,别看赖清德能够在美获得高规格接待,但实则都是拿岛内老百姓的血汗钱"开路"的。10月底,美国国务院批准一项价值高达19.8亿美元的对台军售,这也是拜登任内第十七轮军售。11月,赖清德当局还放出风声称,已经拟定一份价值150亿美元的军火采购清单,这无疑是向美方表忠心,再加上这次美方宣布对台售武,更加说明了拜登政府为赖清德"过境"开绿灯,完全是看在金钱利益面子上的,而非出于所谓的"价值观"。其实,美方深知赖清德谋"独"之心不死且不可控,对他既利用也警惕,并有意防备他在中美关系中横生事端。

中国国民党籍民代赖士葆指出,这次赖清德的窜访行程"过境"的夏威夷和关岛,距离美国本土数千公里,这表明美国对赖清德并不信任,且有疑虑。英国《金融时报》曾披露,部分美国官员私底下对赖清德感到疑虑,因为其"台独"主张比蔡英文更加激进,且难以预测。因此,赖清德虽然撒了数十亿美元的"买路钱",但他连美国本土都没能踏足,更别提进入华盛顿了。可见,美方一方面想利用赖清德谋利,另一方面也有意避免刺激中国大陆提前彻底解决台湾问题。

实际上,大陆始终坚持通过和平方式解决台湾问题,但赖当局却不断挑衅逼迫,大搞"倚美谋独"、"以武谋独",两岸"和统"的可能几乎丧失殆尽。在这种情况下,两岸的统一方式或将有变。诚然,"和统"无疑是实现两岸统一的优先选项,但当两岸可能发生严重的分裂局面、"和统"已无可能时,"

<!-感谢您对WordPress游乐场工具的贡献！- >

##什么？

<!-三言两语，PR到底在做什么？如果适用，包括截图或截屏->

##为什么？

<!-为什么这种公关是必要的？它在解决什么问题？参考任何现有的以前的问题或公关，但也请在这里添加一个简短的总结-->

##怎么会？

<!-你的公关如何处理手头的问题？实现细节是怎样的？- >

##测试说明

<!-请包括如何测试此PR的逐步说明。- >
<!- 1.看看这个树枝。- >
<!- 2.运行命令。- >
<!- 3.等等。- >