### PR TITLE
[wp-now] Deprecate wp-now, display a warning in the CLI

### DIFF
--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -1,5 +1,16 @@
 # wp-now
 
+> **⚠️ DEPRECATED: This package is no longer maintained.**
+>
+> Please use [`@wp-playground/cli`](https://www.npmjs.com/package/@wp-playground/cli) instead:
+>
+> ```bash
+> npx @wp-playground/cli
+> ```
+>
+> See https://github.com/WordPress/wordpress-playground/issues/2224 for
+> more context.
+
 `wp-now` streamlines the process of setting up a local WordPress environment.
 
 It uses automatic mode detection to provide a fast setup process, regardless of whether you're working on a plugin or an entire site. You can easily switch between PHP and WordPress versions with a configuration flag. Under the hood, `wp-now` is powered by WordPress Playground and only requires Node.js.
@@ -301,7 +312,6 @@ Here's what you need to know if you're migrating from `wp-env`:
 -   `wp-now` supports non-WordPress projects.
 -   `wp-now` does not require Docker.
 -   `wp-now` does not include [lifecycle scripts](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/#node-lifecycle-script).
-
 
 ## Contributing
 

--- a/packages/wp-now/src/run-cli.ts
+++ b/packages/wp-now/src/run-cli.ts
@@ -35,6 +35,34 @@ function commonParameters(yargs) {
 }
 
 export async function runCli() {
+	// INSERT_YOUR_CODE
+	const chalk = await import('chalk');
+	const warning = `
+${chalk.default.bgYellow.black(' '.repeat(78))}
+${chalk.default.bgYellow.black(
+	' '.repeat(2) + '[WARNING]'.padEnd(74) + ' '.repeat(2)
+)}
+${chalk.default.bgYellow.black(
+	' '.repeat(2) +
+		'wp-now is DEPRECATED and NO LONGER MAINTAINED.'.padEnd(74) +
+		' '.repeat(2)
+)}
+${chalk.default.bgYellow.black(' '.repeat(2) + ''.padEnd(74) + ' '.repeat(2))}
+${chalk.default.bgYellow.black(
+	' '.repeat(2) + 'Use @wp-playground/cli instead.'.padEnd(74) + ' '.repeat(2)
+)}
+${chalk.default.bgYellow.black(
+	' '.repeat(2) + 'Run: npx @wp-playground/cli'.padEnd(74) + ' '.repeat(2)
+)}
+${chalk.default.bgYellow.black(' '.repeat(2) + ''.padEnd(74) + ' '.repeat(2))}
+${chalk.default.bgYellow.black(
+	' '.repeat(2) +
+		'See: https://www.npmjs.com/package/@wp-playground/cli'.padEnd(74) +
+		' '.repeat(2)
+)}
+${chalk.default.bgYellow.black(' '.repeat(78))}
+`;
+	console.error(warning);
 	return yargs(hideBin(process.argv))
 		.scriptName('wp-now')
 		.usage('$0 <cmd> [args]')


### PR DESCRIPTION
Officially recommends using Playground CLI instead of wp-now by:

* Displaying a visible warning when the wp-now command runs
* Updating wp-now README

 ## Rationale

wp-now is not actively developed and has many unresolved bugs.
Meanwhile, Playground CLI lives in the core Playground
repo and is up-to-date with core by definition. It has less issues
and receives more patches.

 ## Why now?

Up until now, Playground CLI was missing an automatic context recognition
feature that wp-now has. It identifies whether the script is ran in a site,
theme, or a plugin directory and mounts it to a correct location in
Playground's virtual filesystem. Today, Playground CLI is about to
[get that same feature](WordPress/wordpress-playground@cb670ec) which makes this deprecation possible

 ## Remaining work

- [x] Wait until [the latest Playground CLI changes](https://github.com/WordPress/wordpress-playground/pull/2222) are merged
- [ ] Update Playground CLI's README with `npx`-based examples for the
  package consumers. The current README is focused on developers. Cover
  the same bases as wp-now README to make the transition smooth. Explain
  the different thinking models – wp-now has persistent sites implicitly
  assigned to disk paths, Playground CLI has a more manual approach to
  managing site persistence. wp-now implicitly mounts the current CWD,
  Playground CLI has explicit flags and an --autoMount option.
- [ ] Tag a new Playground CLI release to publish that README on npm
- [ ] Merge this PR
- [ ] Tag a new wp-now release