### PR TITLE
[Playground Block] Link "Open in new tab" to playground.wordpress.net

### DIFF
--- a/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
+++ b/packages/wordpress-playground-block/src/components/playground-preview/index.tsx
@@ -324,7 +324,7 @@ function PlaygroundPreview({
 
 	function getFullPageUrl(): string {
 		// Use current URL as an easy-to-reach base URL
-		const fullPageUrl = new URL(location.href);
+		const fullPageUrl = new URL('https://playground.wordpress.net/playground-block-frame.html');
 		// But replace original query params so they cannot interfere
 		fullPageUrl.search = '?playground-full-page';
 

--- a/packages/wordpress-playground-block/wordpress-playground-block.php
+++ b/packages/wordpress-playground-block/wordpress-playground-block.php
@@ -41,31 +41,3 @@ function playground_demo_block_init() {
 	);
 }
 add_action( 'init', 'playground_demo_block_init' );
-
-/**
- * Conditionally render the Playground block as a full, dedicated page.
- */
-function playground_demo_maybe_render_full_page_block() {
-	if (
-		// Skip nonce verification because full-page Playground block
-		// rendering does not require reading or writing server-side state.
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		! isset( $_GET['playground-full-page'], $_GET['playground-attributes'] )
-	) {
-		return;
-	}
-
-	wp_head();
-	$block = array(
-		'blockName'    => 'wordpress-playground/playground',
-		'attrs'        => array(),
-		'innerBlocks'  => array(),
-		'innerHTML'    => '',
-		'innerContent' => array(),
-	);
-	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	echo render_block( $block );
-	wp_footer();
-	die();
-}
-add_action( 'init', 'playground_demo_maybe_render_full_page_block', 9999 );


### PR DESCRIPTION
Rewires the "Open in a new tab" link in the Playground block to go directly to playground.wordpress.net/, see the [related Playground handler logic](https://github.com/WordPress/wordpress-playground/pull/3071).

This commit simplifies the plugin and shifts work from the local site to the Playground.

 ## Testing instructions

1. Start a local dev server via `nx dev wordpress-playground-block`
2. Create a new post
3. Add the Playground block
4. Create a few files in that block
5. Publish the page
6. View the published page
7. Click the "Open in a new tab" link
8. Confirm it opens at playground.wordpress.net
