### PR TITLE
Deprecate wp-now in README and CLI output

### DIFF
--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -1,5 +1,17 @@
 # wp-now
 
+> **Deprecated:** `@wp-now/wp-now` is deprecated and no longer maintained. Use
+> [`@wp-playground/cli`](https://www.npmjs.com/package/@wp-playground/cli)
+> instead:
+>
+> ```bash
+> npx @wp-playground/cli@latest start
+> ```
+>
+> See the
+> [migration guide](https://wordpress.github.io/wordpress-playground/developers/local-development/wp-playground-cli#migrating-from-wp-now)
+> for command mappings and persistence differences.
+
 `wp-now` streamlines the process of setting up a local WordPress environment.
 
 It uses automatic mode detection to provide a fast setup process, regardless of whether you're working on a plugin or an entire site. You can easily switch between PHP and WordPress versions with a configuration flag. Under the hood, `wp-now` is powered by WordPress Playground and only requires Node.js.
@@ -301,7 +313,6 @@ Here's what you need to know if you're migrating from `wp-env`:
 -   `wp-now` supports non-WordPress projects.
 -   `wp-now` does not require Docker.
 -   `wp-now` does not include [lifecycle scripts](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/#node-lifecycle-script).
-
 
 ## Contributing
 

--- a/packages/wp-now/src/run-cli.ts
+++ b/packages/wp-now/src/run-cli.ts
@@ -35,6 +35,8 @@ function commonParameters(yargs) {
 }
 
 export async function runCli() {
+	printDeprecationNotice();
+
 	return yargs(hideBin(process.argv))
 		.scriptName('wp-now')
 		.usage('$0 <cmd> [args]')
@@ -163,6 +165,22 @@ export async function runCli() {
 		.help()
 		.alias('h', 'help')
 		.strict().argv;
+}
+
+function printDeprecationNotice() {
+	console.error(
+		[
+			'',
+			'wp-now is deprecated and no longer maintained.',
+			'Use @wp-playground/cli instead:',
+			'',
+			'  npx @wp-playground/cli@latest start',
+			'',
+			'Migration guide:',
+			'https://wordpress.github.io/wordpress-playground/developers/local-development/wp-playground-cli#migrating-from-wp-now',
+			'',
+		].join('\n')
+	);
 }
 
 function openInDefaultBrowser(url: string) {


### PR DESCRIPTION
## What it does

Displays a deprecation notice whenever `wp-now` runs and adds the same warning to the `@wp-now/wp-now` README.

## Rationale

`wp-now` is no longer maintained and should point users to `@wp-playground/cli`. This is the package-side follow-up to the Playground migration docs.

Supersedes #378 with a smaller patch and without the placeholder code left in that PR.

## Implementation

- Adds a plain stderr deprecation notice at `runCli()` startup.
- Points users to `npx @wp-playground/cli@latest start`.
- Links to the Playground CLI migration guide.
- Adds the same recommendation at the top of the wp-now README.

## Testing instructions

- Ran `git diff --check`.
- Ran `npx --yes prettier@2.6.2 --check packages/wp-now/README.md packages/wp-now/src/run-cli.ts`.

I did not run the full test suite because this checkout does not have dependencies installed.
