### PR TITLE
Build only wp-now in wp-now release workflow

### DIFF
--- a/.github/workflows/release-wp-now.yml
+++ b/.github/workflows/release-wp-now.yml
@@ -44,5 +44,5 @@ jobs:
             - name: Release new version of NPM packages
               shell: bash
               run: |
-                  npm run build
+                  npx nx build wp-now
                   npm run release:wp-now


### PR DESCRIPTION
## Summary\n\nUpdates the manual wp-now release workflow to build only the wp-now package before publishing.\n\nThe workflow currently runs the monorepo-wide build, which fails in unrelated interactive-code-block bundling while resolving PHP WASM JSPI assets, before wp-now can publish.\n\n## Testing\n\nObserved the release workflow pass prepare-playground and fail during the monorepo build before publish.