### PR TITLE
Build wp-now after release version bump

### DIFF
--- a/.github/workflows/release-wp-now.yml
+++ b/.github/workflows/release-wp-now.yml
@@ -43,6 +43,4 @@ jobs:
             # Version bump, release, tag a new version on GitHub
             - name: Release new version of NPM packages
               shell: bash
-              run: |
-                  npx nx build wp-now
-                  npm run release:wp-now
+              run: npm run release:wp-now

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"lint": "nx run-many --all --target=lint",
 		"predeploy": "nx build docs-site",
 		"prepublishOnly": "npm run build",
-		"release:wp-now": "lerna version patch --yes --no-private --loglevel=verbose && cd dist/packages/wp-now && npm publish --access public",
+		"release:wp-now": "lerna version patch --yes --no-private --loglevel=verbose && npx nx build wp-now && cd dist/packages/wp-now && npm publish --access public",
 		"release:vscode": "nx publish vscode-extension",
 		"test": "nx run-many --all --target=test",
 		"fix-asyncify": "node packages/php-wasm/node/bin/rebuild-while-asyncify-functions-missing.mjs",


### PR DESCRIPTION
## Summary\n\nFixes the wp-now release order so the package is built after Lerna bumps the version.\n\nThe failed release showed Lerna bumping the repo to v0.1.75, but npm attempted to publish the already-built dist package as @wp-now/wp-now@0.1.74.\n\n## Testing\n\nConfirmed from the failed release workflow logs that the existing order publishes stale dist package metadata.